### PR TITLE
fix: bump github-actions-models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,9 +489,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "github-actions-models"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911b56ae881f01c777a03472dc5a05310d62db2cf703aab63da9e93f52f3f6f1"
+checksum = "73d8d94bdf9b06536f06ba6d1113657eaae4d5232b87eff8d7f72c03ab268bbd"
 dependencies = [
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.86"
 clap = { version = "4.5.16", features = ["derive", "env"] }
 clap-verbosity-flag = "2.2.1"
 env_logger = "0.11.5"
-github-actions-models = "0.8.0"
+github-actions-models = "0.8.1"
 human-panic = "2.0.1"
 indicatif = "0.17.8"
 itertools = "0.13.0"


### PR DESCRIPTION
Includes https://github.com/woodruffw/github-actions-models/pull/9, which fixes loading for some jobs that use `runs-on` with a group and no labels.