### PR TITLE
fix: use relative workflow paths in SARIF output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,9 @@ fn main() -> Result<()> {
     match format {
         OutputFormat::Plain => render::render_findings(&workflow_registry, &results),
         OutputFormat::Json => serde_json::to_writer_pretty(stdout(), &results)?,
-        OutputFormat::Sarif => serde_json::to_writer_pretty(stdout(), &sarif::build(results))?,
+        OutputFormat::Sarif => {
+            serde_json::to_writer_pretty(stdout(), &sarif::build(&workflow_registry, results))?
+        }
     };
     Ok(())
 }

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -5,17 +5,20 @@ use serde_sarif::sarif::{
     PhysicalLocation, PropertyBag, Region, Result as SarifResult, Run, Sarif, Tool, ToolComponent,
 };
 
-use crate::finding::{Finding, Location};
+use crate::{
+    finding::{Finding, Location},
+    registry::WorkflowRegistry,
+};
 
-pub(crate) fn build(findings: Vec<Finding<'_>>) -> Sarif {
+pub(crate) fn build(registry: &WorkflowRegistry, findings: Vec<Finding<'_>>) -> Sarif {
     Sarif::builder()
         .version("2.1.0")
         .schema("https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-external-property-file-schema-2.1.0.json")
-        .runs([build_run(findings)])
+        .runs([build_run(registry, findings)])
         .build()
 }
 
-fn build_run(findings: Vec<Finding<'_>>) -> Run {
+fn build_run(registry: &WorkflowRegistry, findings: Vec<Finding<'_>>) -> Run {
     Run::builder()
         .tool(
             Tool::builder()
@@ -30,23 +33,23 @@ fn build_run(findings: Vec<Finding<'_>>) -> Run {
                 )
                 .build(),
         )
-        .results(build_results(findings))
+        .results(build_results(registry, findings))
         .build()
 }
 
-fn build_results(findings: Vec<Finding<'_>>) -> Vec<SarifResult> {
-    findings.iter().map(|f| build_result(f)).collect()
+fn build_results(registry: &WorkflowRegistry, findings: Vec<Finding<'_>>) -> Vec<SarifResult> {
+    findings.iter().map(|f| build_result(registry, f)).collect()
 }
 
-fn build_result(finding: &Finding<'_>) -> SarifResult {
+fn build_result(registry: &WorkflowRegistry, finding: &Finding<'_>) -> SarifResult {
     SarifResult::builder()
         .message(finding.ident)
         .rule_id(finding.ident)
-        .locations(build_locations(&finding.locations))
+        .locations(build_locations(registry, &finding.locations))
         .build()
 }
 
-fn build_locations(locations: &[Location<'_>]) -> Vec<SarifLocation> {
+fn build_locations(registry: &WorkflowRegistry, locations: &[Location<'_>]) -> Vec<SarifLocation> {
     locations
         .iter()
         .map(|location| {
@@ -65,8 +68,8 @@ fn build_locations(locations: &[Location<'_>]) -> Vec<SarifLocation> {
                     PhysicalLocation::builder()
                         .artifact_location(
                             ArtifactLocation::builder()
-                                .uri(location.symbolic.name)
-                                .uri_base_id("%workflows%")
+                                .uri_base_id("%SRCROOT%")
+                                .uri(registry.get_workflow_relative_path(location.symbolic.name))
                                 .build(),
                         )
                         .region(


### PR DESCRIPTION
Fixes #57.

Example single SARIF location output with this change:

```json
{
  "logicalLocations": [
    {
      "properties": {
        "symbolic": {
          "annotation": "does not set persist-credentials: false",
          "name": "artipacked.yml",
          "route": {
            "components": [
              {
                "Key": "jobs"
              },
              {
                "Key": "vulnerable-1"
              },
              {
                "Key": "steps"
              },
              {
                "Index": 0
              }
            ]
          }
        }
      }
    }
  ],
  "message": {
    "text": "does not set persist-credentials: false"
  },
  "physicalLocation": {
    "artifactLocation": {
      "uri": ".github/workflows/artipacked.yml",
      "uriBaseId": "%SRCROOT%"
    },
    "region": {
      "endColumn": 80,
      "endLine": 37,
      "snippet": {
        "text": "name: Checkout\n        uses: actions/checkout@v4\n\n      # NOT OK: upload-artifact archives entire repo, including persisted creds"
      },
      "sourceLanguage": "yaml",
      "startColumn": 9,
      "startLine": 34
    }
  }
}
```

(Observe that `logicalLocations` is still just the filename, but `physicalLocations` contains the appropriate relative path.)