### PR TITLE
fix: Always use the plain formatter even when the output is not a terminal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,4 @@
-use std::{
-    io::{stdout, IsTerminal},
-    path::PathBuf,
-    time::Duration,
-};
+use std::{io::stdout, path::PathBuf, time::Duration};
 
 use anyhow::{anyhow, Context, Result};
 use audit::WorkflowAudit;
@@ -47,7 +43,6 @@ struct Args {
     gh_token: Option<String>,
 
     /// The output format to emit. By default, plain text will be emitted
-    /// on an interactive terminal and JSON otherwise.
     #[arg(long, value_enum)]
     format: Option<OutputFormat>,
 
@@ -168,13 +163,7 @@ fn main() -> Result<()> {
     bar.finish_and_clear();
 
     let format = match args.format {
-        None => {
-            if stdout().is_terminal() {
-                OutputFormat::Plain
-            } else {
-                OutputFormat::Json
-            }
-        }
+        None => OutputFormat::Plain,
         Some(f) => f,
     };
 


### PR DESCRIPTION
Fixes #76

I was also looking at whether color support should be modified when the terminal isn't a tty. I think this can be done by enabling supports-colors in owo_colors, although I'm not really a Rust dev and I couldn't quite figure out how to get this working right https://docs.rs/owo-colors/4.1.0/owo_colors/index.html#only-style-on-supported-terminals