### PR TITLE
feat: show version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod utils;
 
 /// Finds security issues in GitHub Actions setups.
 #[derive(Parser)]
+#[command(version)]
 struct Args {
     /// Emit findings even when the context suggests an explicit security decision made by the user.
     #[arg(short, long)]


### PR DESCRIPTION
`zizmor --version` now emits the version set in `Cargo.toml`