### PR TITLE
fix: finding url link to audits doc

### DIFF
--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -226,7 +226,7 @@ pub(crate) struct Finding<'w> {
 impl<'w> Finding<'w> {
     pub(crate) fn url(&self) -> String {
         format!(
-            "{repo}/tree/main/docs/audit/{ident}.md",
+            "{repo}/blob/main/docs/audits.md#{ident}",
             repo = env!("CARGO_PKG_REPOSITORY"),
             ident = self.ident
         )


### PR DESCRIPTION
👋 Hey William, thanks for this tool it is very useful !

Here is a tiny PR to fix the URLs displayed in the CLI reports, the current ones are returning a 404.

E.g: Artipacked is currently https://github.com/woodruffw/zizmor/tree/main/docs/audit/artipacked.md
but it should be https://github.com/woodruffw/zizmor/blob/main/docs/audits.md#artipacked 