### PR TITLE
fix(ci): move read permissions to job scope

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,14 +7,12 @@ on:
   pull_request:
     branches: ["*"]
 
-permissions:
-  contents: read
-
 jobs:
   zizmor:
     name: Zizmor latest via Cargo
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Setting permissions at the Job level, this overrides the parent `contents: read` setting, failing for private repositories.