### PR TITLE
docs: add an example GHA workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,5 +1,4 @@
-# https://github.com/woodruffw/zizmor
-name: GitHub Actions Security Analysis with Zizmor
+name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
@@ -9,7 +8,7 @@ on:
 
 jobs:
   zizmor:
-    name: Zizmor latest via Cargo
+    name: zizmor latest via Cargo
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,13 +22,12 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Get zizmor
         run: cargo install zizmor
-      - name: Run zizmor
+      - name: Run zizmor 🌈
         run: zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:
-          # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif
-          # Optional category for the results
-          # Used to differentiate multiple results for one commit
           category: zizmor

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,7 +53,7 @@ easy way to do it is with a workflow that connects to
 The following is an example of such a workflow:
 
 ```yaml title="zizmor.yml"
-name: GitHub Actions Security Analysis with Zizmor
+name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
   push:
@@ -63,7 +63,7 @@ on:
 
 jobs:
   zizmor:
-    name: Zizmor latest via Cargo
+    name: zizmor latest via Cargo
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -77,7 +77,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Get zizmor
         run: cargo install zizmor
-      - name: Run zizmor
+      - name: Run zizmor 🌈
         run: zizmor --format sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # (1)!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,10 +20,14 @@ theme:
   name: material
   palette:
     scheme: slate
+  icon:
+    annotation: material/arrow-right-circle
   features:
     - navigation.expand
     - navigation.sections
     - navigation.tracking
+    - content.code.copy
+    - content.code.annotate
 
 markdown_extensions:
   # Makes sure we render `<https://...>`-style links correctly.
@@ -33,6 +37,7 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - md_in_html
+  - attr_list
   - toc:
       permalink: 🔗
 


### PR DESCRIPTION
Adds an annotated version of this repo's `zizmor.yml` to the docs.

See #89.
See #69.