### PR TITLE
Improves plain output with audit confidence

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -102,11 +102,17 @@ pub(crate) fn render_findings(registry: &WorkflowRegistry, findings: &[Finding])
 
 fn render_finding(registry: &WorkflowRegistry, finding: &Finding) {
     let link = Link::new(finding.ident, &finding.url()).to_string();
+    let confidence = format!(
+        "audit confidence → {:?}",
+        &finding.determinations.confidence
+    );
+    let confidence_footer = Level::Note.title(&confidence);
 
     let message = Level::from(&finding.determinations.severity)
         .title(finding.desc)
         .id(&link)
-        .snippets(finding_snippet(registry, finding));
+        .snippets(finding_snippet(registry, finding))
+        .footer(confidence_footer);
 
     let renderer = Renderer::styled();
     println!("{}", renderer.render(message));


### PR DESCRIPTION
Self-explained. This is a super simple proposal, eventually we can improve by implementing `Display` for `Confidence`, adding colors, etc.

Testing this PR : 

- Pull this branch
- Run against some Workflow with existing audits

```
cargo run -- tests/test-data/hardcoded-credentials.yml

🌈 completed hardcoded-credentials.yml
error[hardcoded-container-credentials]: hardcoded credential in GitHub Actions container configurations
  --> tests/test-data/hardcoded-credentials.yml:15:7
   |
15 |         credentials:
   |  _______^
16 | |         username: user
17 | |         password: hackme
   | |________________________^ container registry password is hard-coded
   |
   = note: audit confidence → High
```