### PR TITLE
refactor: clean up expr APIs slightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1122,16 @@ checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -2263,6 +2279,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,6 +2310,7 @@ dependencies = [
  "owo-colors",
  "pest",
  "pest_derive",
+ "pretty_assertions",
  "reqwest",
  "serde",
  "serde-sarif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,5 @@ lto = true
 
 [dev-dependencies]
 assert_cmd = "2.0.16"
+pretty_assertions = "1.4.1"
 serde_json_path = "0.7.1"


### PR DESCRIPTION
Reduce the amount of explicit boxing needed.