### PR TITLE
feat: analyze expressions for safety

### DIFF
--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -342,6 +342,8 @@ mod tests {
             ("some.context.*.something", false),
             // More complicated cases:
             ("some.condition && '--some-arg' || ''", true),
+            ("some.condition && some.context || ''", false),
+            ("some.condition && '--some-arg' || some.context", false),
         ];
 
         for (case, safe) in cases {

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -61,7 +61,7 @@ impl TemplateInjection {
     /// can only ever return a literal node (i.e. bool, number, string, etc.).
     /// All branches/flows of the expression must uphold that invariant;
     /// no taint tracking is currently done.
-    fn expr_is_safe(&self, expr: &Expr) -> bool {
+    fn expr_is_safe(expr: &Expr) -> bool {
         match expr {
             Expr::Number(_) => true,
             Expr::String(_) => true,
@@ -89,7 +89,7 @@ impl TemplateInjection {
                     // regardless of the actual operation type. This could be
                     // refined to check only one side with taint information.
                     // TODO: Relax this for >/>=/</<=?
-                    _ => self.expr_is_safe(lhs) && self.expr_is_safe(rhs),
+                    _ => Self::expr_is_safe(lhs) && Self::expr_is_safe(rhs),
                 }
             }
             Expr::UnOp { op, .. } => match op {
@@ -158,7 +158,7 @@ impl TemplateInjection {
             // Filter "safe" expressions (ones that might expand to code,
             // but not arbitrary code) by default, unless we're operating
             // in pedantic mode.
-            if self.expr_is_safe(&expr) && !self.state.pedantic {
+            if Self::expr_is_safe(&expr) && !self.state.pedantic {
                 continue;
             }
 

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -344,6 +344,10 @@ mod tests {
             ("some.condition && '--some-arg' || ''", true),
             ("some.condition && some.context || ''", false),
             ("some.condition && '--some-arg' || some.context", false),
+            (
+                "(github.actor != 'github-actions[bot]' && github.actor) || 'BrewTestBot'",
+                false,
+            ),
         ];
 
         for (case, safe) in cases {

--- a/src/expr/expr.pest
+++ b/src/expr/expr.pest
@@ -5,24 +5,40 @@
 /// Whitespace handling
 WHITESPACE = _{ " " }
 
+// Misc notes:
+// I have pretty low confidence in this grammar -- it should parse the
+// overwhelming majority of normal looking Actions expressions, but
+// it makes up for a lack of left-recursion with some hacky rules that
+// probably aren't sufficient for capturing all possible grammar productions.
+// I've noted some of these with `HACK` below.
+// I've also noted some potentials TODOs with `TODO`.
+
 expression = { SOI ~ or_expr ~ EOI }
 
 /// Logical OR
-or_expr = { and_expr ~ ("||" ~ and_expr)* }
+or_expr = { (and_expr ~ ("||" ~ and_expr)*) }
 
 /// Logical AND
-and_expr = { eq_expr ~ ("&&" ~ eq_expr)* }
+and_expr = { (eq_expr ~ ("&&" ~ eq_expr)*) }
 
 /// Structural equality/inequality
-eq_expr = { comp_expr ~ (eq_op ~ comp_expr)* }
+eq_expr = { (comp_expr ~ (eq_op ~ comp_expr)*) }
 eq_op   = { "==" | "!=" }
 
 /// Structural comparison
-comp_expr = { unary_expr ~ (comp_op ~ unary_expr)* }
+// HACK: parenthetical production of or_expr here to
+// allow left-parenthetical productions like `(foo || bar) == baz`.
+// This works well, but I'm not convinced it's right.
+comp_expr = {
+    unary_expr ~ (comp_op ~ unary_expr)*
+  | ("(" ~ or_expr ~ ")")
+}
 comp_op   = { ">" | ">=" | "<" | "<=" }
 
 /// Unary operations, including the base case for expressions.
-unary_expr = { unary_op? ~ primary_expr }
+// HACK: `unary_op ~ or_expr` ensures that we handle non-trivial
+// negation productions, like `!(true || false)`.
+unary_expr = { (unary_op? ~ primary_expr) | unary_op ~ or_expr }
 unary_op   = { "!" }
 
 primary_expr = {
@@ -37,6 +53,8 @@ primary_expr = {
 }
 
 /// Numbers
+// TODO: Support hex numbers and exponent forms?
+// Unclear whether these are supported by Actions itself.
 number = @{ "-"? ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ ("." ~ ASCII_DIGIT+)? }
 
 /// Strings

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -417,6 +417,10 @@ mod tests {
                 },
             ),
             (
+                "vegetables.*.ediblePortions",
+                Expr::Context("vegetables.*.ediblePortions".into()),
+            ),
+            (
                 // Sanity check for our associativity: the top level Expr here
                 // should be `BinOp::Or`.
                 "github.ref == 'refs/heads/main' && 'value_for_main_branch' || 'value_for_other_branches'",

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -226,8 +226,7 @@ pub(crate) struct Finding<'w> {
 impl<'w> Finding<'w> {
     pub(crate) fn url(&self) -> String {
         format!(
-            "{repo}/blob/main/docs/audits.md#{ident}",
-            repo = env!("CARGO_PKG_REPOSITORY"),
+            "https://woodruffw.github.io/zizmor/audits#{ident}",
             ident = self.ident
         )
     }


### PR DESCRIPTION
~~WIP, needs tests.~~

This will improve `template-injection`'s precision by allowing it to filter expressions that are "safe," i.e. can't produce arbitrary input-derived code regardless of how they're executed.

For now, as "safe" expression is defined as:

1. Any primitive (null, number, string, etc.)
2. `!{expr}`
3. `{expr} == {expr}` and `{expr} != {expr}`
4. Any other binary expression where both the LHS and RHS are themselves safe per cases 1-3

Notably, this means that some expressions that contain code or can be evaluated to code *will* be considered safe, since that code will effectively be static within those expressions and not derived from user input (i.e. context accesses). 