### PR TITLE
feat: Exclude safe values from template injection rule

### DIFF
--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -51,6 +51,10 @@ const SAFE_CONTEXTS: &[&str] = &[
     "github.workspace",
     // GitHub Actions-controller runner architecture.
     "runner.arch",
+    // Debug logging is (1) or is not (0) enabled on GitHub Actions runner.
+    "runner.debug",
+    // GitHub Actions runner operating system.
+    "runner.os",
 ];
 
 impl TemplateInjection {


### PR DESCRIPTION
GitHub provides the following and I don't see a way an attacker could hijack them:

* runner.debug
* runner.os
* runner.temp

(runner.arch was already excluded from the check)