### PR TITLE
fix: bump github-actions-models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -534,9 +534,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "github-actions-models"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6300ec1b57d79c856128e90fe8944e9cb0e27da710d812907b55797b31a17cd"
+checksum = "bf113470eb36ec542d7fb000aaa227c76f9b33342f6870796ceb620898f3e26b"
 dependencies = [
  "serde",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = "1.0.92"
 clap = { version = "4.5.16", features = ["derive", "env"] }
 clap-verbosity-flag = "2.2.1"
 env_logger = "0.11.5"
-github-actions-models = "0.8.4"
+github-actions-models = "0.9.0"
 human-panic = "2.0.1"
 indicatif = "0.17.8"
 itertools = "0.13.0"


### PR DESCRIPTION
Brings in https://github.com/woodruffw/github-actions-models/issues/14.