### PR TITLE
feat: exit code support

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,6 +38,22 @@ zizmor --format sarif
 
 See [Integration](#integration) for suggestions on when to use each format.
 
+## Exit codes
+
+`zizmor` uses various exit codes to summarize the results of a run:
+
+| Code | Meaning |
+| ---- | ------- |
+| 0    | Successful audit; no findings to report. |
+| 1    | Error during audit; consult output. |
+| 10   | One or more findings found; highest finding is "unknown" level. |
+| 11   | One or more findings found; highest finding is "informational" level. |
+| 12   | One or more findings found; highest finding is "low" level. |
+| 13   | One or more findings found; highest finding is "medium" level. |
+| 14   | One or more findings found; highest finding is "high" level. |
+
+All other exit codes are currently reserved.
+
 ## Ignoring results
 
 `zizmor`'s defaults are not always 100% right for every possible use case.

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -22,7 +22,7 @@ pub(crate) enum Confidence {
     High,
 }
 
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialOrd, PartialEq, Serialize)]
 pub(crate) enum Severity {
     #[default]
     Unknown,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,11 +1,16 @@
 //! Functionality for registering and managing the lifecycles of
 //! audits.
 
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, path::Path, process::ExitCode};
 
 use anyhow::{anyhow, Result};
 
-use crate::{audit::WorkflowAudit, models::Workflow};
+use crate::{
+    audit::WorkflowAudit,
+    config::Config,
+    finding::{Finding, Severity},
+    models::Workflow,
+};
 
 pub(crate) struct WorkflowRegistry {
     pub(crate) workflows: HashMap<String, Workflow>,
@@ -98,5 +103,70 @@ impl AuditRegistry {
         &mut self,
     ) -> std::collections::hash_map::IterMut<'_, &str, Box<dyn WorkflowAudit>> {
         self.workflow_audits.iter_mut()
+    }
+}
+
+/// A registry of all findings discovered during a `zizmor` run.
+pub(crate) struct FindingRegistry<'a> {
+    config: &'a Config,
+    ignored: Vec<Finding<'a>>,
+    findings: Vec<Finding<'a>>,
+    highest_severity: Option<Severity>,
+}
+
+impl<'a> FindingRegistry<'a> {
+    pub(crate) fn new(config: &'a Config) -> Self {
+        Self {
+            config,
+            ignored: Default::default(),
+            findings: Default::default(),
+            highest_severity: None,
+        }
+    }
+
+    /// Adds one or more findings to the current findings set,
+    /// filtering with the configuration in the process.
+    pub(crate) fn extend(&mut self, results: Vec<Finding<'a>>) {
+        // TODO: is it faster to iterate like this, or do `find_by_max`
+        // and then `extend`?
+        for result in results {
+            if self.config.ignores(&result) {
+                self.ignored.push(result);
+            } else {
+                if self
+                    .highest_severity
+                    .map_or(true, |s| result.determinations.severity > s)
+                {
+                    self.highest_severity = Some(result.determinations.severity);
+                }
+
+                self.findings.push(result);
+            }
+        }
+    }
+
+    /// All non-filtered findings.
+    pub(crate) fn findings(&self) -> &[Finding<'a>] {
+        &self.findings
+    }
+
+    /// All filtered findings.
+    pub(crate) fn ignored(&self) -> &[Finding<'a>] {
+        &self.ignored
+    }
+}
+
+impl From<FindingRegistry<'_>> for ExitCode {
+    fn from(value: FindingRegistry<'_>) -> Self {
+        match value.highest_severity {
+            Some(sev) => match sev {
+                Severity::Unknown => ExitCode::from(10),
+                Severity::Informational => ExitCode::from(11),
+                Severity::Low => ExitCode::from(12),
+                Severity::Medium => ExitCode::from(13),
+                Severity::High => ExitCode::from(14),
+            },
+            None => ExitCode::SUCCESS,
+        }
     }
 }

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -10,7 +10,7 @@ use crate::{
     registry::WorkflowRegistry,
 };
 
-pub(crate) fn build(registry: &WorkflowRegistry, findings: Vec<Finding<'_>>) -> Sarif {
+pub(crate) fn build(registry: &WorkflowRegistry, findings: &[Finding]) -> Sarif {
     Sarif::builder()
         .version("2.1.0")
         .schema("https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-external-property-file-schema-2.1.0.json")
@@ -18,7 +18,7 @@ pub(crate) fn build(registry: &WorkflowRegistry, findings: Vec<Finding<'_>>) -> 
         .build()
 }
 
-fn build_run(registry: &WorkflowRegistry, findings: Vec<Finding<'_>>) -> Run {
+fn build_run(registry: &WorkflowRegistry, findings: &[Finding]) -> Run {
     Run::builder()
         .tool(
             Tool::builder()
@@ -37,7 +37,7 @@ fn build_run(registry: &WorkflowRegistry, findings: Vec<Finding<'_>>) -> Run {
         .build()
 }
 
-fn build_results(registry: &WorkflowRegistry, findings: Vec<Finding<'_>>) -> Vec<SarifResult> {
+fn build_results(registry: &WorkflowRegistry, findings: &[Finding]) -> Vec<SarifResult> {
     findings.iter().map(|f| build_result(registry, f)).collect()
 }
 

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -40,9 +40,9 @@ fn audit_artipacked() -> anyhow::Result<()> {
     let auditable = workflow_under_test("artipacked.yml");
     let cli_args = [&auditable];
 
-    let execution = zizmor().args(cli_args).unwrap();
+    let execution = zizmor().args(cli_args).output()?;
 
-    assert!(execution.status.success());
+    assert_eq!(execution.status.code(), Some(13));
 
     let findings = serde_json::from_slice(&execution.stdout)?;
 
@@ -61,9 +61,9 @@ fn audit_excessive_permission() -> anyhow::Result<()> {
     let auditable = workflow_under_test("excessive-permissions.yml");
     let cli_args = [&auditable];
 
-    let execution = zizmor().args(cli_args).unwrap();
+    let execution = zizmor().args(cli_args).output()?;
 
-    assert!(execution.status.success());
+    assert_eq!(execution.status.code(), Some(14));
 
     let findings = serde_json::from_slice(&execution.stdout)?;
 
@@ -82,9 +82,9 @@ fn audit_hardcoded_credentials() -> anyhow::Result<()> {
     let auditable = workflow_under_test("hardcoded-credentials.yml");
     let cli_args = [&auditable];
 
-    let execution = zizmor().args(cli_args).unwrap();
+    let execution = zizmor().args(cli_args).output()?;
 
-    assert!(execution.status.success());
+    assert_eq!(execution.status.code(), Some(14));
 
     let findings = serde_json::from_slice(&execution.stdout)?;
 
@@ -103,9 +103,9 @@ fn audit_template_injection() -> anyhow::Result<()> {
     let auditable = workflow_under_test("template-injection.yml");
     let cli_args = [&auditable];
 
-    let execution = zizmor().args(cli_args).unwrap();
+    let execution = zizmor().args(cli_args).output()?;
 
-    assert!(execution.status.success());
+    assert_eq!(execution.status.code(), Some(14));
 
     let findings = serde_json::from_slice(&execution.stdout)?;
 
@@ -124,9 +124,9 @@ fn audit_use_trusted_publishing() -> anyhow::Result<()> {
     let auditable = workflow_under_test("use-trusted-publishing.yml");
     let cli_args = [&auditable];
 
-    let execution = zizmor().args(cli_args).unwrap();
+    let execution = zizmor().args(cli_args).output()?;
 
-    assert!(execution.status.success());
+    assert_eq!(execution.status.code(), Some(11));
 
     let findings = serde_json::from_slice(&execution.stdout)?;
 
@@ -147,9 +147,9 @@ fn audit_self_hosted() -> anyhow::Result<()> {
     // Note : self-hosted audit is pedantic
     let cli_args = ["--pedantic", &auditable];
 
-    let execution = zizmor().args(cli_args).unwrap();
+    let execution = zizmor().args(cli_args).output()?;
 
-    assert!(execution.status.success());
+    assert_eq!(execution.status.code(), Some(10));
 
     let findings = serde_json::from_slice(&execution.stdout)?;
 


### PR DESCRIPTION
This adds consistent error codes to `zizmor`. The meanings of the codes are added to the docs as well, but to copy them here:

| Code | Meaning |
| ---- | ------- |
| 0    | Successful audit; no findings to report. |
| 1    | Error during audit; consult output. |
| 10   | One or more findings found; highest finding is "unknown" level. |
| 11   | One or more findings found; highest finding is "informational" level. |
| 12   | One or more findings found; highest finding is "low" level. |
| 13   | One or more findings found; highest finding is "medium" level. |
| 14   | One or more findings found; highest finding is "high" level. |

Closes #86.