### PR TITLE
fix: exclude information about the repo and owner

### DIFF
--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -39,6 +39,13 @@ const SAFE_CONTEXTS: &[&str] = &[
     // Safe keys within the otherwise generally unsafe github.event context.
     "github.event.number",
     "github.event.workflow_run.id",
+    // Information about the GitHub repostory
+    "github.repository",
+    "github.repository_id",
+    "github.repostoryUrl",
+    // Information about the GitHub repository owner (account/org or ID)
+    "github.repository_owner",
+    "github.repository_owner_id",
     // Unique numbers assigned by GitHub for workflow runs
     "github.run_attempt",
     "github.run_id",


### PR DESCRIPTION
This would seem to fall into the category of "if these values are unsafe, we have bigger problems to deal with"