### PR TITLE
docs: update version in pre-commit hook

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -183,7 +183,7 @@ To do so, add the following to your `.pre-commit-config.yaml` `repos` section:
 
 ```yaml
 -   repo: https://github.com/woodruffw/zizmor
-    rev: v0.1.6 # (1)!
+    rev: v0.3.0 # (1)!
     hooks:
     - id: zizmor
 ```


### PR DESCRIPTION
Ciao! Didn't open an issue for this as it seemed straightforward. I know you suggest the users to update the hook version, but I figured it wouldn't be bad to update from time to time.

This pull request consists of an update to the documentation to reflect the latest version of zizmor in the suggested pre-commit-config file.

* [`docs/usage.md`](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476L186-R186): Updated the version of the `zizmor` repository from `v0.1.6` to `v0.3.0` in the `.pre-commit-config.yaml` file.