### PR TITLE
docs: add continue-on-error to action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -23,7 +23,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -26,24 +26,24 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@c14a0593fa503d0af0f4c9fb8ce8c7e1d9c496f9 # v3
 
       - name: build site
         run: make site
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site_html
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
 
 jobs:
   zizmor:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -24,7 +24,9 @@ jobs:
         run: cargo install zizmor
       - name: Run zizmor 🌈
         continue-on-error: true
-        run: zizmor --format sarif . > results.sarif
+        run: |
+          zizmor --format sarif . > results.sarif
+          cat results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           zizmor --format sarif . > results.sarif || true
           cat results.sarif
+          echo test
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,9 +25,8 @@ jobs:
       - name: Run zizmor 🌈
         continue-on-error: true
         run: |
+          zizmor .
           zizmor --format sarif . > results.sarif || true
-          cat results.sarif
-          echo test
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
+        # with:
+        #   persist-credentials: false
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1
       - name: Get zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run zizmor 🌈
         continue-on-error: true
         run: |
-          zizmor --format sarif . > results.sarif
+          zizmor --format sarif . > results.sarif || true
           cat results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,11 +15,11 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
       - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1
       - name: Get zizmor
         run: cargo install zizmor
       - name: Run zizmor 🌈
@@ -27,7 +27,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@4e7d89f9f0a59fd9d68561cfbfd15475eaf75298 # v3
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Get zizmor
         run: cargo install zizmor
       - name: Run zizmor 🌈
+        continue-on-error: true
         run: zizmor --format sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Run zizmor 🌈
         continue-on-error: true
         run: |
-          zizmor -vv .
           zizmor --format sarif . > results.sarif || true
         # env:
         #   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -27,8 +27,8 @@ jobs:
         run: |
           zizmor -vv .
           zizmor --format sarif . > results.sarif || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # env:
+        #   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@4e7d89f9f0a59fd9d68561cfbfd15475eaf75298 # v3
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run zizmor 🌈
         continue-on-error: true
         run: |
-          zizmor .
+          zizmor -vv .
           zizmor --format sarif . > results.sarif || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,9 +151,10 @@ jobs:
       - name: Get zizmor
         run: cargo install zizmor
       - name: Run zizmor 🌈
+        continue-on-error: true # (1)!
         run: zizmor --format sarif . > results.sarif
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # (1)!
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # (2)!
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:
@@ -161,7 +162,8 @@ jobs:
           category: zizmor
 ```
 
-1. Optional: Remove the `env:` block to only run `zizmor`'s offline audits.
+1. Prevents `zizmor`'s [exit codes](#exit-codes) from interfering with SARIF uploading.
+2. Optional: Remove the `env:` block to only run `zizmor`'s offline audits.
 
 For more inspiration, see `zizmor`'s own [repository workflow scan], as well
 as  GitHub's example of [running ESLint] as a security workflow.


### PR DESCRIPTION
Addding `continue-on-error` prevents zizmor's exit codes from interfering with SARIF upload in the following step.