### PR TITLE
feat: --no-exit-codes + sarif tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,7 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zizmor"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "annotate-snippets",
  "anstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zizmor"
 description = "Finds security issues in GitHub Actions setups"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 repository = "https://github.com/woodruffw/zizmor"
 homepage = "https://github.com/woodruffw/zizmor"

--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -15,5 +15,6 @@ Options:
       --format <FORMAT>      The output format to emit. By default, plain text will be emitted [possible values: plain, json, sarif]
   -c, --config <CONFIG>      The configuration file to load. By default, any config will be discovered relative to $CWD
       --no-config            Disable all configuration loading
+      --no-exit-codes        Disable all error codes besides success and tool failure
   -h, --help                 Print help
   -V, --version              Print version

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,11 +46,16 @@ See [Integration](#integration) for suggestions on when to use each format.
 
 ## Exit codes
 
+!!! note
+
+    Exit codes 10 and above are **not used** if `--no-exit-codes` or
+    `--format sarif` is passed.
+
 `zizmor` uses various exit codes to summarize the results of a run:
 
 | Code | Meaning |
 | ---- | ------- |
-| 0    | Successful audit; no findings to report. |
+| 0    | Successful audit; no findings to report (or SARIF mode enabled). |
 | 1    | Error during audit; consult output. |
 | 10   | One or more findings found; highest finding is "unknown" level. |
 | 11   | One or more findings found; highest finding is "informational" level. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,10 @@ struct App {
     #[arg(long, group = "conf")]
     no_config: bool,
 
+    /// Disable all error codes besides success and tool failure.
+    #[arg(long)]
+    no_exit_codes: bool,
+
     /// The workflow filenames or directories to audit.
     #[arg(required = true)]
     inputs: Vec<PathBuf>,
@@ -197,7 +201,11 @@ fn run() -> Result<ExitCode> {
         )?,
     };
 
-    Ok(results.into())
+    if args.no_exit_codes || matches!(format, OutputFormat::Sarif) {
+        Ok(ExitCode::SUCCESS)
+    } else {
+        Ok(results.into())
+    }
 }
 
 fn main() -> ExitCode {


### PR DESCRIPTION
Disables the special (>10) exit codes when
`--no-exit-codes` or `--format sarif` is passed,
leaving just success (0) and general tool failure
(1).

Closes #153.