### PR TITLE
fix(cli): fixup error printing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use std::{io::stdout, path::PathBuf, process::ExitCode, time::Duration};
 
+use anstream::eprintln;
 use anyhow::{anyhow, Context, Result};
 use audit::WorkflowAudit;
 use clap::{Parser, ValueEnum};
@@ -125,7 +126,9 @@ fn run() -> Result<ExitCode> {
 
     let mut workflow_registry = WorkflowRegistry::new();
     for workflow_path in workflow_paths.iter() {
-        workflow_registry.register_workflow(workflow_path)?;
+        workflow_registry
+            .register_workflow(workflow_path)
+            .with_context(|| "failed to register workflow")?;
     }
 
     let mut audit_registry = AuditRegistry::new();
@@ -213,6 +216,9 @@ fn main() -> ExitCode {
     // we always exit cleanly, rather than performing a hard process exit.
     match run() {
         Ok(exit) => exit,
-        Err(_) => ExitCode::FAILURE,
+        Err(err) => {
+            eprintln!("{err:?}");
+            ExitCode::FAILURE
+        }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -3,7 +3,7 @@
 
 use std::{collections::HashMap, path::Path, process::ExitCode};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 
 use crate::{
     audit::WorkflowAudit,
@@ -39,7 +39,10 @@ impl WorkflowRegistry {
             return Err(anyhow!("can't register {name} more than once"));
         }
 
-        self.workflows.insert(name, Workflow::from_file(path)?);
+        self.workflows.insert(
+            name,
+            Workflow::from_file(path).with_context(|| "couldn't load workflow from file")?,
+        );
 
         Ok(())
     }


### PR DESCRIPTION
This fixes a regression when error codes were added: we began suppressing the actual error message, making it much harder to diagnose errors in e.g. workflow parsing.