### PR TITLE
Fix singular and plural for 'findings'

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -97,9 +97,11 @@ pub(crate) fn render_findings(registry: &WorkflowRegistry, findings: &FindingReg
         }
 
         if findings.ignored().is_empty() {
+            let nfindings = findings.findings().len();
             print!(
-                "{nfindings} findings: ",
-                nfindings = (findings.findings().len() + findings.ignored().len()).green(),
+                "{nfindings} finding{s}: ",
+                nfindings = nfindings.green(),
+                s = if nfindings == 1 { "" } else { "s" },
             );
         } else {
             print!(


### PR DESCRIPTION
Fix "1 findings" -> "1 finding" and keep "2 findings".

# Before

```console
❯ zizmor .
🌈 completed main.yml
🌈 completed deploy.yml
🌈 completed lint.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/cherry-picker/.github/workflows/lint.yml:16:9
   |
16 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

1 findings: 0 unknown, 0 informational, 0 low, 1 medium, 0 high
```

# After

```console
❯ /tmp/zizmor/target/debug/zizmor .
🌈 completed lint.yml
🌈 completed main.yml
🌈 completed deploy.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> /Users/hugo/github/cherry-picker/.github/workflows/lint.yml:16:9
   |
16 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

1 finding: 0 unknown, 0 informational, 0 low, 1 medium, 0 high
```

