### PR TITLE
Only deploy to GitHub Pages for upstream

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -37,6 +37,7 @@ jobs:
         run: make site
 
       - name: Setup Pages
+        if: github.repository_owner == 'woodruffw'
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
@@ -45,5 +46,6 @@ jobs:
           path: site_html
 
       - name: Deploy to GitHub Pages
+        if: github.repository_owner == 'woodruffw'
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
This currently fails for forks:

```
Run actions/configure-pages@v5
Error: Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the `enablement` parameter for this action. Error: Not Found - https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site
Error: HttpError: Not Found - https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site
```

https://github.com/hugovk/zizmor/actions/runs/11869198332/job/33079257598

Skip the Pages setup and deploy, keep the site build and artifacts upload, so forks can ensure they don't break the docs build.