### PR TITLE
Fix typos including `github.repostoryUrl` -> `github.repositoryUrl`

### DIFF
--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -2,7 +2,7 @@
 //!
 //! This is similar to "impostor" commit detection, but with only named
 //! refs instead of fully pinned commits: a user may pin a ref such as
-//! `@foo` thinking that `foo` will alway refer to either a branch or a tag,
+//! `@foo` thinking that `foo` will always refer to either a branch or a tag,
 //! but the upstream repository may host *both* a branch and a tag named
 //! `foo`, making it unclear to the end user which is selected.
 

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -40,10 +40,10 @@ const SAFE_CONTEXTS: &[&str] = &[
     "github.event.number",
     "github.event.merge_group.base_sha",
     "github.event.workflow_run.id",
-    // Information about the GitHub repostory
+    // Information about the GitHub repository
     "github.repository",
     "github.repository_id",
-    "github.repostoryUrl",
+    "github.repositoryUrl",
     // Information about the GitHub repository owner (account/org or ID)
     "github.repository_owner",
     "github.repository_owner_id",


### PR DESCRIPTION
One of these likely causes a bug in functionality.

Here's the correct spelling also in the docs:

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context

Found with https://github.com/codespell-project/actions-codespell.