### PR TITLE
refactor: simplify use of WorkflowAudit trait

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -127,12 +127,12 @@ Some things that can be useful to discuss beforehand:
 - Which criticality should we assign for this new finding?
 - Which confidence should we assign for this new finding?
 - Should this new audit be pedantic at all?
-- Does this new audit require using the Github API, or is it entirely off-line?
+- Does this new audit require using the Github API, or is it entirely offline?
 
 When developing a new `zizmor` audit, there are a couple of implementation details to be aware of:
 
 - All existing audits live in a Rust modules grouped under `src/audit` folder
-- The expected behaviour for all audits is defined by the `WorkflowAudit` trait at `src/audit/mod.rs`
+- The expected behavior for all audits is defined by the `WorkflowAudit` trait at `src/audit/mod.rs`
 - The expected outcome of an executed audit is defined by the `Finding` struct at `src/finding/mod.rs`
 - Any `WorkflowAudit` implementation can have access to an `AuditState` instance, as per `src/state.rs`
 - If an audit requires data from the GitHub API, there is a `Client` implementation at `src/github_api.rs`
@@ -148,20 +148,31 @@ cargo test
 
 ### Adding a new audit
 
+!!! tip
+
+    `WorkflowAudit` has various default implementations that are useful if your
+    audit only needs to look at individual jobs, steps, etc.
+
+    For example, you may want to implement `WorkflowAudit::audit_step` to
+    audit each step individually rather than having to iterate from the workflow
+    downwards with `WorkflowAudit::audit`.
+
+!!! tip
+
+    When in doubt, refer to pre-existing audits for inspiration!
+
 The general procedure for adding a new audit can be described as:
 
 - Define a new file at `src/audit/my_new_audit.rs`
 - Define a struct like `MyNewAudit` and implement the `WorkflowAudit` trait for it
-- You may want to use both the `AuditState` and `github_api::Client` to get the job done
-- Assign the proper YML `location` when creating a `Finding`, grabbing it from the proper `Workflow`, `Job` or `Step` instance
+    - You may want to use both the `AuditState` and `github_api::Client` to get the job done
+- Assign the proper `location` when creating a `Finding`, grabbing it from the
+  proper `Workflow`, `Job` or `Step` instance
 - Register `MyNewAudit` in the known audits at `src/main.rs`
 - Add proper integration tests covering some scenarios at `tests/acceptance.rs`
-- Add proper docs for this new audit at `docs/audits`. Please add related public information about the underlying vulnerability
+- Add proper docs for this new audit at `docs/audits`. Please add related public
+  information about the underlying vulnerability
 - Open your Pull Request!
-
-!!! tip
-
-    When in doubt, you can always refer to existing audit implementations as well!
 
 ### Changing an existing audit
 
@@ -171,7 +182,7 @@ The general procedure for changing an existing audit is:
 - Change the behaviour to match new requirements there (e.g. consuming a new CLI info exposed through `AuditState`)
 - Ensure that tests and samples at `tests/` reflect changed behaviour accordingly (e.g. the confidence for finding has changed)
 - Ensure that `docs/audits` reflect changed behaviour accordingly (e.g. an audit that is no longer pedantic)
-- Open your Pull Request
+- Open your Pull Request!
 
 ## Changing `zizmor`'s CLI
 

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -34,32 +34,19 @@ pub(crate) trait WorkflowAudit {
     where
         Self: Sized;
 
-    fn audit_step<'w>(
-        &self,
-        _workflow: &'w Workflow,
-        _job: &Job<'w>,
-        _step: &Step<'w>,
-    ) -> Result<Vec<Finding<'w>>> {
+    fn audit_step<'w>(&self, _step: &Step<'w>) -> Result<Vec<Finding<'w>>> {
         Ok(vec![])
     }
 
-    fn audit_normal_job<'w>(
-        &self,
-        workflow: &'w Workflow,
-        job: &Job<'w>,
-    ) -> Result<Vec<Finding<'w>>> {
+    fn audit_normal_job<'w>(&self, job: &Job<'w>) -> Result<Vec<Finding<'w>>> {
         let mut results = vec![];
         for step in job.steps() {
-            results.extend(self.audit_step(workflow, job, &step)?);
+            results.extend(self.audit_step(&step)?);
         }
         Ok(results)
     }
 
-    fn audit_reusable_job<'w>(
-        &self,
-        _workflow: &'w Workflow,
-        _job: &Job<'w>,
-    ) -> Result<Vec<Finding<'w>>> {
+    fn audit_reusable_job<'w>(&self, _job: &Job<'w>) -> Result<Vec<Finding<'w>>> {
         Ok(vec![])
     }
 
@@ -69,10 +56,10 @@ pub(crate) trait WorkflowAudit {
         for job in workflow.jobs() {
             match *job {
                 github_actions_models::workflow::Job::NormalJob(_) => {
-                    results.extend(self.audit_normal_job(workflow, &job)?);
+                    results.extend(self.audit_normal_job(&job)?);
                 }
                 github_actions_models::workflow::Job::ReusableWorkflowCallJob(_) => {
-                    results.extend(self.audit_reusable_job(workflow, &job)?);
+                    results.extend(self.audit_reusable_job(&job)?);
                 }
             }
         }

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use crate::{
     finding::{Finding, FindingBuilder},
-    models::Workflow,
+    models::{Job, Step, Workflow},
     state::AuditState,
 };
 
@@ -34,7 +34,51 @@ pub(crate) trait WorkflowAudit {
     where
         Self: Sized;
 
-    fn audit<'w>(&self, workflow: &'w Workflow) -> Result<Vec<Finding<'w>>>;
+    fn audit_step<'w>(
+        &self,
+        _workflow: &'w Workflow,
+        _job: &Job<'w>,
+        _step: &Step<'w>,
+    ) -> Result<Vec<Finding<'w>>> {
+        Ok(vec![])
+    }
+
+    fn audit_normal_job<'w>(
+        &self,
+        workflow: &'w Workflow,
+        job: &Job<'w>,
+    ) -> Result<Vec<Finding<'w>>> {
+        let mut results = vec![];
+        for step in job.steps() {
+            results.extend(self.audit_step(workflow, job, &step)?);
+        }
+        Ok(results)
+    }
+
+    fn audit_reusable_job<'w>(
+        &self,
+        _workflow: &'w Workflow,
+        _job: &Job<'w>,
+    ) -> Result<Vec<Finding<'w>>> {
+        Ok(vec![])
+    }
+
+    fn audit<'w>(&self, workflow: &'w Workflow) -> Result<Vec<Finding<'w>>> {
+        let mut results = vec![];
+
+        for job in workflow.jobs() {
+            match *job {
+                github_actions_models::workflow::Job::NormalJob(_) => {
+                    results.extend(self.audit_normal_job(workflow, &job)?);
+                }
+                github_actions_models::workflow::Job::ReusableWorkflowCallJob(_) => {
+                    results.extend(self.audit_reusable_job(workflow, &job)?);
+                }
+            }
+        }
+
+        Ok(results)
+    }
 
     fn finding<'w>() -> FindingBuilder<'w>
     where

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -1,8 +1,6 @@
-use github_actions_models::workflow::Job;
-
 use crate::finding::{Confidence, Severity};
 
-use super::{AuditState, Finding, Workflow, WorkflowAudit};
+use super::{AuditState, Finding, Job, Step, Workflow, WorkflowAudit};
 
 pub(crate) struct UnpinnedUses {}
 
@@ -28,35 +26,30 @@ impl WorkflowAudit for UnpinnedUses {
         Ok(Self {})
     }
 
-    fn audit<'w>(&self, workflow: &'w Workflow) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_step<'w>(
+        &self,
+        workflow: &'w Workflow,
+        _job: &Job<'w>,
+        step: &Step<'w>,
+    ) -> anyhow::Result<Vec<Finding<'w>>> {
         let mut findings = vec![];
 
-        for job in workflow.jobs() {
-            // No point in checking reusable workflows, since they
-            // require a ref pin when used outside of the local repo.
-            let Job::NormalJob(_) = *job else {
-                continue;
-            };
+        let Some(uses) = step.uses() else {
+            return Ok(vec![]);
+        };
 
-            for step in job.steps() {
-                let Some(uses) = step.uses() else {
-                    continue;
-                };
-
-                if uses.unpinned() {
-                    findings.push(
-                        Self::finding()
-                            .confidence(Confidence::High)
-                            .severity(Severity::Informational)
-                            .add_location(
-                                step.location().with_keys(&["uses".into()]).annotated(
-                                    "action is not pinned to a tag, branch, or hash ref",
-                                ),
-                            )
-                            .build(workflow)?,
-                    );
-                }
-            }
+        if uses.unpinned() {
+            findings.push(
+                Self::finding()
+                    .confidence(Confidence::High)
+                    .severity(Severity::Informational)
+                    .add_location(
+                        step.location()
+                            .with_keys(&["uses".into()])
+                            .annotated("action is not pinned to a tag, branch, or hash ref"),
+                    )
+                    .build(workflow)?,
+            );
         }
 
         Ok(findings)

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -1,6 +1,6 @@
 use crate::finding::{Confidence, Severity};
 
-use super::{AuditState, Finding, Job, Step, Workflow, WorkflowAudit};
+use super::{AuditState, Finding, Step, WorkflowAudit};
 
 pub(crate) struct UnpinnedUses {}
 
@@ -26,12 +26,7 @@ impl WorkflowAudit for UnpinnedUses {
         Ok(Self {})
     }
 
-    fn audit_step<'w>(
-        &self,
-        workflow: &'w Workflow,
-        _job: &Job<'w>,
-        step: &Step<'w>,
-    ) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
         let mut findings = vec![];
 
         let Some(uses) = step.uses() else {
@@ -48,7 +43,7 @@ impl WorkflowAudit for UnpinnedUses {
                             .with_keys(&["uses".into()])
                             .annotated("action is not pinned to a tag, branch, or hash ref"),
                     )
-                    .build(workflow)?,
+                    .build(step.workflow())?,
             );
         }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -95,7 +95,7 @@ impl<'w> Job<'w> {
 
     /// Returns this job's parent [`Workflow`]
     pub(crate) fn parent(&self) -> &'w Workflow {
-        &self.parent
+        self.parent
     }
 
     pub(crate) fn location(&self) -> SymbolicLocation<'w> {
@@ -174,7 +174,7 @@ impl<'w> Step<'w> {
 
     /// Returns this step's (grand)parent [`Workflow`].
     pub(crate) fn workflow(&self) -> &'w Workflow {
-        &self.parent().parent()
+        self.parent().parent()
     }
 
     /// Returns a [`Uses`] for this [`Step`], if it has one.

--- a/src/models.rs
+++ b/src/models.rs
@@ -183,7 +183,7 @@ impl<'w> Step<'w> {
     /// Note that this returns the [`NormalJob`], not the wrapper [`Job`].
     pub(crate) fn job(&self) -> &'w NormalJob {
         match *self.parent {
-            workflow::Job::NormalJob(job) => &job,
+            workflow::Job::NormalJob(job) => job,
             // NOTE(ww): Unreachable because steps are always parented by normal jobs.
             workflow::Job::ReusableWorkflowCallJob(_) => unreachable!(),
         }


### PR DESCRIPTION
Very WIP. 

TODO:

- [x] ~~Refactor `self-hosted-runner`~~ (N/A)
- [x] ~~Refactor `ref-confusion`~~ (N/A, not worth refactoring)
- [x] Refactor `known-vulnerable-actions`
- [x] ~~Refactor `insecure-commands`~~ (Nothing to refactor, since this audit begins at the workflow level)
- [x] ~~Refactor `impostor-commit`~~ (N/A, not worth refactoring)
- [x] ~~Refactor `hardcoded-container-credentials`~~ (N/A, not worth refactoring)
- [x] Refactor ~~`excessive-permissions`~~ (Nothing to refactor, since this audit begins at the workflow level)
- [x] ~~Refactor `dangerous-triggers`~~ (Nothing to refactor, since this audit begins at the workflow level)
- [x] ~~Refactor `artipacked`~~ (N/A, not worth refactoring)
- [x] Update audit writing/editing docs

The plan here is to refactor `WorkflowAudit` so that it contains a waterfall of default calls:

```
audit -> audit_{normal,reusable}_job -> audit_step
```

...which will enable simpler audit implementations, since an audit that only deals with individual steps will be able to implement just `audit_step` without having to write the outer loops + filtering manually.

CC @ubiratansoares -- this refactor might interest you, since it should make writing audits much more fluid/fluent :slightly_smiling_face: 