### PR TITLE
feat: adds support to inlined ignores

### DIFF
--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -300,7 +300,7 @@ impl<'w> FindingBuilder<'w> {
             })
             .collect::<Vec<_>>();
 
-        let inlined_ignore = format!("zizmor: ignore[{}]", id);
+        let inlined_ignore = format!("# zizmor: ignore[{}]", id);
         for (start, end) in line_ranges {
             for document_line in start..(end + 1) {
                 if let Some(line) = document_lines.get(document_line) {

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -304,7 +304,7 @@ impl<'w> FindingBuilder<'w> {
         for (start, end) in line_ranges {
             for document_line in start..(end + 1) {
                 if let Some(line) = document_lines.get(document_line) {
-                    if line.contains(&inlined_ignore) {
+                    if line.rfind(&inlined_ignore).is_some() {
                         return true;
                     }
                 }

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -222,7 +222,7 @@ pub(crate) struct Finding<'w> {
     pub(crate) url: &'static str,
     pub(crate) determinations: Determinations,
     pub(crate) locations: Vec<Location<'w>>,
-    pub(crate) ignored_from_inlined_comment: bool,
+    pub(crate) ignored: bool,
 }
 
 pub(crate) struct FindingBuilder<'w> {
@@ -279,7 +279,7 @@ impl<'w> FindingBuilder<'w> {
                 severity: self.severity,
             },
             locations,
-            ignored_from_inlined_comment: should_ignore,
+            ignored: should_ignore,
         })
     }
 
@@ -289,7 +289,7 @@ impl<'w> FindingBuilder<'w> {
         locations: &[Location],
         id: &str,
     ) -> bool {
-        let document_lines = &workflow.contents.lines().collect::<Vec<_>>();
+        let document_lines = &workflow.document.source().lines().collect::<Vec<_>>();
         let line_ranges = locations
             .iter()
             .map(|l| {

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -222,6 +222,7 @@ pub(crate) struct Finding<'w> {
     pub(crate) url: &'static str,
     pub(crate) determinations: Determinations,
     pub(crate) locations: Vec<Location<'w>>,
+    pub(crate) ignored_from_inlined_comment: bool,
 }
 
 pub(crate) struct FindingBuilder<'w> {
@@ -261,6 +262,14 @@ impl<'w> FindingBuilder<'w> {
     }
 
     pub(crate) fn build(self, workflow: &'w Workflow) -> Result<Finding<'w>> {
+        let locations = self
+            .locations
+            .iter()
+            .map(|l| l.clone().concretize(workflow))
+            .collect::<Result<Vec<_>>>()?;
+
+        let should_ignore = self.ignored_from_inlined_comment(workflow, &locations, self.ident);
+
         Ok(Finding {
             ident: self.ident,
             desc: self.desc,
@@ -269,11 +278,39 @@ impl<'w> FindingBuilder<'w> {
                 confidence: self.confidence,
                 severity: self.severity,
             },
-            locations: self
-                .locations
-                .into_iter()
-                .map(|l| l.concretize(workflow))
-                .collect::<Result<Vec<_>>>()?,
+            locations,
+            ignored_from_inlined_comment: should_ignore,
         })
+    }
+
+    fn ignored_from_inlined_comment(
+        &self,
+        workflow: &Workflow,
+        locations: &[Location],
+        id: &str,
+    ) -> bool {
+        let document_lines = &workflow.contents.lines().collect::<Vec<_>>();
+        let line_ranges = locations
+            .iter()
+            .map(|l| {
+                (
+                    l.concrete.location.start_point.row,
+                    l.concrete.location.end_point.row,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let inlined_ignore = format!("zizmor: ignore[{}]", id);
+        for (start, end) in line_ranges {
+            for document_line in start..(end + 1) {
+                if let Some(line) = document_lines.get(document_line) {
+                    if line.contains(&inlined_ignore) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        false
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,13 +177,12 @@ fn run() -> Result<ExitCode> {
             workflow = workflow.filename().cyan()
         ));
         for (name, audit) in audit_registry.iter_workflow_audits() {
-            let findings = audit.audit(workflow).with_context(|| {
+            results.extend(audit.audit(workflow).with_context(|| {
                 format!(
                     "{name} failed on {workflow}",
                     workflow = workflow.filename()
                 )
-            })?;
-            results.extend(findings);
+            })?);
             bar.inc(1);
         }
         bar.println(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,12 +177,13 @@ fn run() -> Result<ExitCode> {
             workflow = workflow.filename().cyan()
         ));
         for (name, audit) in audit_registry.iter_workflow_audits() {
-            results.extend(audit.audit(workflow).with_context(|| {
+            let findings = audit.audit(workflow).with_context(|| {
                 format!(
                     "{name} failed on {workflow}",
                     workflow = workflow.filename()
                 )
-            })?);
+            })?;
+            results.extend(workflow, findings);
             bar.inc(1);
         }
         bar.println(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ fn run() -> Result<ExitCode> {
                     workflow = workflow.filename()
                 )
             })?;
-            results.extend(workflow, findings);
+            results.extend(findings);
             bar.inc(1);
         }
         bar.println(format!(

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,7 +17,6 @@ use crate::finding::{Route, SymbolicLocation};
 /// providing access to the underlying data model.
 pub(crate) struct Workflow {
     pub(crate) path: String,
-    pub(crate) contents: String,
     pub(crate) document: yamlpath::Document,
     inner: workflow::Workflow,
 }
@@ -46,7 +45,6 @@ impl Workflow {
                 .to_str()
                 .ok_or_else(|| anyhow!("invalid workflow: path is not UTF-8"))?
                 .to_string(),
-            contents,
             document,
             inner,
         })

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,6 +17,7 @@ use crate::finding::{Route, SymbolicLocation};
 /// providing access to the underlying data model.
 pub(crate) struct Workflow {
     pub(crate) path: String,
+    pub(crate) contents: String,
     pub(crate) document: yamlpath::Document,
     inner: workflow::Workflow,
 }
@@ -32,12 +33,12 @@ impl Deref for Workflow {
 impl Workflow {
     /// Load a workflow from the given file on disk.
     pub(crate) fn from_file<P: AsRef<Path>>(p: P) -> Result<Self> {
-        let raw = std::fs::read_to_string(p.as_ref())?;
+        let contents = std::fs::read_to_string(p.as_ref())?;
 
-        let inner = serde_yaml::from_str(&raw)
+        let inner = serde_yaml::from_str(&contents)
             .with_context(|| format!("invalid GitHub Actions workflow: {:?}", p.as_ref()))?;
 
-        let document = yamlpath::Document::new(raw)?;
+        let document = yamlpath::Document::new(&contents)?;
 
         Ok(Self {
             path: p
@@ -45,6 +46,7 @@ impl Workflow {
                 .to_str()
                 .ok_or_else(|| anyhow!("invalid workflow: path is not UTF-8"))?
                 .to_string(),
+            contents,
             document,
             inner,
         })

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -128,13 +128,11 @@ impl<'a> FindingRegistry<'a> {
 
     /// Adds one or more findings to the current findings set,
     /// filtering with the configuration in the process.
-    pub(crate) fn extend(&mut self, workflow: &Workflow, results: Vec<Finding<'a>>) {
+    pub(crate) fn extend(&mut self, results: Vec<Finding<'a>>) {
         // TODO: is it faster to iterate like this, or do `find_by_max`
         // and then `extend`?
         for finding in results {
-            if self.config.ignores(&finding)
-                || self.ignored_from_inlined_comment(workflow, &finding)
-            {
+            if self.config.ignores(&finding) || finding.ignored_from_inlined_comment {
                 self.ignored.push(finding);
             } else {
                 if self
@@ -157,33 +155,6 @@ impl<'a> FindingRegistry<'a> {
     /// All filtered findings.
     pub(crate) fn ignored(&self) -> &[Finding<'a>] {
         &self.ignored
-    }
-
-    fn ignored_from_inlined_comment(&self, workflow: &Workflow, finding: &Finding) -> bool {
-        let document_lines = &workflow.contents.split("\n").collect::<Vec<_>>();
-        let line_ranges = finding
-            .locations
-            .iter()
-            .map(|l| {
-                (
-                    l.concrete.location.start_point.row,
-                    l.concrete.location.end_point.row,
-                )
-            })
-            .collect::<Vec<_>>();
-
-        let inlined_ignore = format!("zizmor: ignore[{}]", finding.ident);
-        for (start, end) in line_ranges {
-            for document_line in start..(end + 1) {
-                if let Some(line) = document_lines.get(document_line) {
-                    if line.contains(&inlined_ignore) {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        false
     }
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -132,7 +132,7 @@ impl<'a> FindingRegistry<'a> {
         // TODO: is it faster to iterate like this, or do `find_by_max`
         // and then `extend`?
         for finding in results {
-            if self.config.ignores(&finding) || finding.ignored_from_inlined_comment {
+            if self.config.ignores(&finding) || finding.ignored {
                 self.ignored.push(finding);
             } else {
                 if self

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -36,6 +36,23 @@ fn assert_value_match(json: &Value, path_pattern: &str, value: &str) {
 }
 
 #[test]
+fn catches_inlined_ignore() -> anyhow::Result<()> {
+    let auditable = workflow_under_test("inlined-ignores.yml");
+
+    let cli_args = [&auditable];
+
+    let execution = zizmor().args(cli_args).output()?;
+
+    assert_eq!(execution.status.code(), Some(0));
+
+    let findings = String::from_utf8(execution.stdout)?;
+
+    assert_eq!(&findings, "[]");
+
+    Ok(())
+}
+
+#[test]
 fn audit_artipacked() -> anyhow::Result<()> {
     let auditable = workflow_under_test("artipacked.yml");
     let cli_args = [&auditable];

--- a/tests/test-data/inlined-ignores.yml
+++ b/tests/test-data/inlined-ignores.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  artipacked-ignored:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4 # zizmor: ignore[artipacked]
+
+  insecure-commands-ignored:
+    runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: yes # zizmor: ignore[insecure-commands]
+    steps:
+      - run: echo "I shall pass!"
+
+  hardcoded-credentials-ignored:
+    runs-on: ubuntu-latest
+    container:
+      image: fake.example.com/example
+      credentials:
+        username: user
+        password: hackme # zizmor: ignore[hardcoded-container-credentials]
+    steps:
+      - run: echo 'This is a honeypot actually!'


### PR DESCRIPTION
Closes #124 

There are 2 approaches here

- https://github.com/woodruffw/zizmor/commit/8f1a18cd3ec00da493502df35abacd1ec32756f4 propose a change at `FindingRegistry` level
- https://github.com/woodruffw/zizmor/commit/14d2dd04b0341fa176b2ad6e2ebbc5073243e076 proposes a change at `FindingBuilder` level

In both of them the core remains the same : 

- we cache the YAML string contents at `Workflow` 
- we use `Finding.location` to extract the start and end rows related to the impacted snippet
- we loop through the lines, checking whether or not we have a comment disabling that particular check

Happy to iterate on this idea. If one of them makes sense, happy to add a commit with proper docs

How to test

- Pull this branch
- Run

```bash
cargo run -- tests/test-data/inlined-ignores.yml
```

```
➜  zizmor git:(ufs/patch-06) cargo run -- tests/test-data/inlined-ignores.yml
   Compiling zizmor v0.4.0 (/Users/lonewolf/RustroverProjects/zizmor)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.20s
     Running `target/debug/zizmor tests/test-data/inlined-ignores.yml`
🌈 completed inlined-ignores.yml
No findings to report. Good job! (3 ignored)
```