### PR TITLE
refactor: add Audit supertrait

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -164,7 +164,9 @@ cargo test
 The general procedure for adding a new audit can be described as:
 
 - Define a new file at `src/audit/my_new_audit.rs`
-- Define a struct like `MyNewAudit` and implement the `WorkflowAudit` trait for it
+- Define a struct like `MyNewAudit`
+- Use the `audit_meta!` macro to implement `Audit` for `MyNewAudit`
+- Implement the `WorkflowAudit` trait for `MyNewAudit`
     - You may want to use both the `AuditState` and `github_api::Client` to get the job done
 - Assign the proper `location` when creating a `Finding`, grabbing it from the
   proper `Workflow`, `Job` or `Step` instance

--- a/src/audit/artipacked.rs
+++ b/src/audit/artipacked.rs
@@ -7,7 +7,7 @@ use github_actions_models::{
 };
 use itertools::Itertools;
 
-use super::WorkflowAudit;
+use super::{audit_meta, WorkflowAudit};
 use crate::{
     finding::{Confidence, Finding, Severity},
     state::AuditState,
@@ -17,6 +17,12 @@ use crate::{models::Workflow, utils::split_patterns};
 pub(crate) struct Artipacked {
     pub(crate) state: AuditState,
 }
+
+audit_meta!(
+    Artipacked,
+    "artipacked",
+    "credential persistence through GitHub Actions artifacts"
+);
 
 impl Artipacked {
     fn dangerous_artifact_patterns<'b>(&self, path: &'b str) -> Vec<&'b str> {
@@ -41,17 +47,6 @@ impl Artipacked {
 }
 
 impl WorkflowAudit for Artipacked {
-    fn ident() -> &'static str {
-        "artipacked"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "credential persistence through GitHub Actions artifacts"
-    }
-
     fn new(state: AuditState) -> Result<Self> {
         Ok(Self { state })
     }

--- a/src/audit/dangerous_triggers.rs
+++ b/src/audit/dangerous_triggers.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use github_actions_models::workflow::event::{BareEvent, OptionalBody};
 use github_actions_models::workflow::Trigger;
 
-use super::WorkflowAudit;
+use super::{audit_meta, WorkflowAudit};
 use crate::finding::{Confidence, Finding, Severity};
 use crate::models::Workflow;
 use crate::state::AuditState;
@@ -11,18 +11,13 @@ pub(crate) struct DangerousTriggers {
     pub(crate) _state: AuditState,
 }
 
+audit_meta!(
+    DangerousTriggers,
+    "dangerous-triggers",
+    "use of fundamentally insecure workflow trigger"
+);
+
 impl WorkflowAudit for DangerousTriggers {
-    fn ident() -> &'static str {
-        "dangerous-triggers"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "use of fundamentally insecure workflow trigger"
-    }
-
     fn new(state: AuditState) -> Result<Self> {
         Ok(Self { _state: state })
     }

--- a/src/audit/excessive_permissions.rs
+++ b/src/audit/excessive_permissions.rs
@@ -5,7 +5,7 @@ use github_actions_models::{
     workflow::Job,
 };
 
-use super::WorkflowAudit;
+use super::{audit_meta, WorkflowAudit};
 use crate::{
     finding::{Confidence, Severity},
     AuditState,
@@ -33,25 +33,17 @@ static KNOWN_PERMISSIONS: LazyLock<HashMap<&str, Severity>> = LazyLock::new(|| {
     .into()
 });
 
+audit_meta!(
+    ExcessivePermissions,
+    "excessive-permissions",
+    "overly broad workflow or job-level permissions"
+);
+
 pub(crate) struct ExcessivePermissions {
     pub(crate) _config: AuditState,
 }
 
 impl WorkflowAudit for ExcessivePermissions {
-    fn ident() -> &'static str
-    where
-        Self: Sized,
-    {
-        "excessive-permissions"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "overly broad workflow or job-level permissions"
-    }
-
     fn new(config: AuditState) -> anyhow::Result<Self>
     where
         Self: Sized,

--- a/src/audit/hardcoded_container_credentials.rs
+++ b/src/audit/hardcoded_container_credentials.rs
@@ -8,7 +8,7 @@ use github_actions_models::{
     },
 };
 
-use super::WorkflowAudit;
+use super::{audit_meta, WorkflowAudit};
 use crate::{
     finding::{Confidence, Severity},
     state::AuditState,
@@ -16,21 +16,13 @@ use crate::{
 
 pub(crate) struct HardcodedContainerCredentials {}
 
+audit_meta!(
+    HardcodedContainerCredentials,
+    "hardcoded-container-credentials",
+    "hardcoded credential in GitHub Actions container configurations"
+);
+
 impl WorkflowAudit for HardcodedContainerCredentials {
-    fn ident() -> &'static str
-    where
-        Self: Sized,
-    {
-        "hardcoded-container-credentials"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "hardcoded credential in GitHub Actions container configurations"
-    }
-
     fn new(_state: AuditState) -> anyhow::Result<Self>
     where
         Self: Sized,

--- a/src/audit/impostor_commit.rs
+++ b/src/audit/impostor_commit.rs
@@ -8,7 +8,7 @@
 use anyhow::{anyhow, Result};
 use github_actions_models::workflow::Job;
 
-use super::WorkflowAudit;
+use super::{audit_meta, WorkflowAudit};
 use crate::{
     finding::{Confidence, Finding, Severity},
     github_api::{self, Branch, ComparisonStatus, Tag},
@@ -21,6 +21,12 @@ pub const IMPOSTOR_ANNOTATION: &str = "uses a commit that doesn't belong to the 
 pub(crate) struct ImpostorCommit {
     pub(crate) client: github_api::Client,
 }
+
+audit_meta!(
+    ImpostorCommit,
+    "impostor-commit",
+    "commit with no history in referenced repository"
+);
 
 impl ImpostorCommit {
     fn named_refs(&self, uses: RepositoryUses<'_>) -> Result<(Vec<Branch>, Vec<Tag>)> {
@@ -109,17 +115,6 @@ impl ImpostorCommit {
 }
 
 impl WorkflowAudit for ImpostorCommit {
-    fn ident() -> &'static str {
-        "impostor-commit"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "commit with no history in referenced repository"
-    }
-
     fn new(state: AuditState) -> Result<Self> {
         if state.offline {
             return Err(anyhow!("offline audits only requested"));

--- a/src/audit/insecure_commands.rs
+++ b/src/audit/insecure_commands.rs
@@ -1,5 +1,5 @@
 use crate::audit::WorkflowAudit;
-use crate::finding::{Confidence, Finding, FindingBuilder, Severity, SymbolicLocation};
+use crate::finding::{Confidence, Finding, Severity, SymbolicLocation};
 use crate::models::{Steps, Workflow};
 use crate::state::AuditState;
 use github_actions_models::common::{Env, EnvValue};
@@ -7,10 +7,15 @@ use github_actions_models::workflow::job::StepBody;
 use github_actions_models::workflow::Job;
 use std::ops::Deref;
 
-static ID: &str = "insecure-commands";
-static DESCRIPTION: &str = "execution of insecure workflow commands is enabled";
+use super::audit_meta;
 
 pub(crate) struct InsecureCommands;
+
+audit_meta!(
+    InsecureCommands,
+    "insecure-commands",
+    "execution of insecure workflow commands is enabled"
+);
 
 impl InsecureCommands {
     fn insecure_commands_allowed<'w>(
@@ -18,7 +23,7 @@ impl InsecureCommands {
         workflow: &'w Workflow,
         location: SymbolicLocation<'w>,
     ) -> Finding<'w> {
-        FindingBuilder::new(ID, DESCRIPTION)
+        Self::finding()
             .confidence(Confidence::High)
             .severity(Severity::High)
             .add_location(
@@ -60,20 +65,6 @@ impl InsecureCommands {
 }
 
 impl WorkflowAudit for InsecureCommands {
-    fn ident() -> &'static str
-    where
-        Self: Sized,
-    {
-        ID
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        DESCRIPTION
-    }
-
     fn new(_: AuditState) -> anyhow::Result<Self>
     where
         Self: Sized,

--- a/src/audit/known_vulnerable_actions.rs
+++ b/src/audit/known_vulnerable_actions.rs
@@ -14,11 +14,17 @@ use crate::{
     state::AuditState,
 };
 
-use super::WorkflowAudit;
+use super::{audit_meta, WorkflowAudit};
 
 pub(crate) struct KnownVulnerableActions {
     client: github_api::Client,
 }
+
+audit_meta!(
+    KnownVulnerableActions,
+    "known-vulnerable-actions",
+    "action has a known vulnerability"
+);
 
 impl KnownVulnerableActions {
     fn action_known_vulnerabilities(
@@ -115,20 +121,6 @@ impl KnownVulnerableActions {
 }
 
 impl WorkflowAudit for KnownVulnerableActions {
-    fn ident() -> &'static str
-    where
-        Self: Sized,
-    {
-        "known-vulnerable-actions"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "action has a known vulnerability"
-    }
-
     fn new(state: AuditState) -> anyhow::Result<Self>
     where
         Self: Sized,

--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -11,7 +11,7 @@ use std::ops::Deref;
 use anyhow::{anyhow, Result};
 use github_actions_models::workflow::Job;
 
-use super::WorkflowAudit;
+use super::{audit_meta, WorkflowAudit};
 use crate::{
     finding::{Confidence, Severity},
     github_api,
@@ -25,6 +25,12 @@ const REF_CONFUSION_ANNOTATION: &str =
 pub(crate) struct RefConfusion {
     client: github_api::Client,
 }
+
+audit_meta!(
+    RefConfusion,
+    "ref-confusion",
+    "git ref for action with ambiguous ref type"
+);
 
 impl RefConfusion {
     fn confusable(&self, uses: &RepositoryUses) -> Result<bool> {
@@ -51,20 +57,6 @@ impl RefConfusion {
 }
 
 impl WorkflowAudit for RefConfusion {
-    fn ident() -> &'static str
-    where
-        Self: Sized,
-    {
-        "ref-confusion"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "git ref for action with ambiguous ref type"
-    }
-
     fn new(state: AuditState) -> anyhow::Result<Self>
     where
         Self: Sized,

--- a/src/audit/self_hosted_runner.rs
+++ b/src/audit/self_hosted_runner.rs
@@ -16,27 +16,19 @@ use github_actions_models::{
     workflow::{job::RunsOn, Job},
 };
 
-use super::WorkflowAudit;
+use super::{audit_meta, WorkflowAudit};
 
 pub(crate) struct SelfHostedRunner {
     pub(crate) state: AuditState,
 }
 
+audit_meta!(
+    SelfHostedRunner,
+    "self-hosted-runner",
+    "runs on a self-hosted runner"
+);
+
 impl WorkflowAudit for SelfHostedRunner {
-    fn ident() -> &'static str
-    where
-        Self: Sized,
-    {
-        "self-hosted-runner"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "runs on a self-hosted runner"
-    }
-
     fn new(state: AuditState) -> anyhow::Result<Self>
     where
         Self: Sized,

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -17,7 +17,7 @@ use github_actions_models::{
     workflow::job::{Matrix, NormalJob, StepBody, Strategy},
 };
 
-use super::WorkflowAudit;
+use super::{audit_meta, WorkflowAudit};
 use crate::{
     expr::{BinOp, Expr, UnOp},
     finding::{Confidence, Severity},
@@ -28,6 +28,12 @@ use crate::{
 pub(crate) struct TemplateInjection {
     pub(crate) state: AuditState,
 }
+
+audit_meta!(
+    TemplateInjection,
+    "template-injection",
+    "code injection via template expansion"
+);
 
 /// Context members that are believed to be always safe.
 const SAFE_CONTEXTS: &[&str] = &[
@@ -233,20 +239,6 @@ impl TemplateInjection {
 }
 
 impl WorkflowAudit for TemplateInjection {
-    fn ident() -> &'static str
-    where
-        Self: Sized,
-    {
-        "template-injection"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "code injection via template expansion"
-    }
-
     fn new(state: AuditState) -> anyhow::Result<Self>
     where
         Self: Sized,

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -2,7 +2,7 @@ use crate::finding::{Confidence, Severity};
 
 use super::{audit_meta, AuditState, Finding, Step, WorkflowAudit};
 
-pub(crate) struct UnpinnedUses {}
+pub(crate) struct UnpinnedUses;
 
 audit_meta!(UnpinnedUses, "unpinned-uses", "unpinned action reference");
 
@@ -11,7 +11,7 @@ impl WorkflowAudit for UnpinnedUses {
     where
         Self: Sized,
     {
-        Ok(Self {})
+        Ok(Self)
     }
 
     fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -1,24 +1,12 @@
 use crate::finding::{Confidence, Severity};
 
-use super::{AuditState, Finding, Step, WorkflowAudit};
+use super::{audit_meta, AuditState, Finding, Step, WorkflowAudit};
 
 pub(crate) struct UnpinnedUses {}
 
+audit_meta!(UnpinnedUses, "unpinned-uses", "unpinned action reference");
+
 impl WorkflowAudit for UnpinnedUses {
-    fn ident() -> &'static str
-    where
-        Self: Sized,
-    {
-        "unpinned-uses"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "unpinned action reference"
-    }
-
     fn new(_state: AuditState) -> anyhow::Result<Self>
     where
         Self: Sized,

--- a/src/audit/use_trusted_publishing.rs
+++ b/src/audit/use_trusted_publishing.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, ops::Deref};
 use anyhow::Ok;
 use github_actions_models::{common::EnvValue, workflow::job::StepBody};
 
-use super::WorkflowAudit;
+use super::{audit_meta, WorkflowAudit};
 use crate::{
     finding::{Confidence, Severity},
     state::AuditState,
@@ -20,6 +20,12 @@ const KNOWN_PYTHON_TP_INDICES: &[&str] = &[
 pub(crate) struct UseTrustedPublishing {
     pub(crate) _state: AuditState,
 }
+
+audit_meta!(
+    UseTrustedPublishing,
+    "use-trusted-publishing",
+    "prefer trusted publishing for authentication"
+);
 
 impl UseTrustedPublishing {
     fn pypi_publish_uses_manual_credentials(&self, with: &HashMap<String, EnvValue>) -> bool {
@@ -59,17 +65,6 @@ impl UseTrustedPublishing {
 }
 
 impl WorkflowAudit for UseTrustedPublishing {
-    fn ident() -> &'static str {
-        "use-trusted-publishing"
-    }
-
-    fn desc() -> &'static str
-    where
-        Self: Sized,
-    {
-        "prefer trusted publishing for authentication"
-    }
-
     fn new(state: AuditState) -> anyhow::Result<Self> {
         Ok(Self { _state: state })
     }

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -219,32 +219,26 @@ pub(crate) struct Determinations {
 pub(crate) struct Finding<'w> {
     pub(crate) ident: &'static str,
     pub(crate) desc: &'static str,
+    pub(crate) url: &'static str,
     pub(crate) determinations: Determinations,
     pub(crate) locations: Vec<Location<'w>>,
-}
-
-impl<'w> Finding<'w> {
-    pub(crate) fn url(&self) -> String {
-        format!(
-            "https://woodruffw.github.io/zizmor/audits#{ident}",
-            ident = self.ident
-        )
-    }
 }
 
 pub(crate) struct FindingBuilder<'w> {
     ident: &'static str,
     desc: &'static str,
+    url: &'static str,
     severity: Severity,
     confidence: Confidence,
     locations: Vec<SymbolicLocation<'w>>,
 }
 
 impl<'w> FindingBuilder<'w> {
-    pub(crate) fn new(ident: &'static str, desc: &'static str) -> Self {
+    pub(crate) fn new(ident: &'static str, desc: &'static str, url: &'static str) -> Self {
         Self {
             ident,
             desc,
+            url,
             severity: Default::default(),
             confidence: Default::default(),
             locations: vec![],
@@ -270,6 +264,7 @@ impl<'w> FindingBuilder<'w> {
         Ok(Finding {
             ident: self.ident,
             desc: self.desc,
+            url: self.url,
             determinations: Determinations {
                 confidence: self.confidence,
                 severity: self.severity,

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,7 @@ fn run() -> Result<ExitCode> {
     let mut audit_registry = AuditRegistry::new();
     macro_rules! register_audit {
         ($rule:path) => {{
+            use crate::audit::Audit as _;
             // HACK: https://github.com/rust-lang/rust/issues/48067
             use $rule as base;
             match base::new(audit_state.clone()) {

--- a/src/render.rs
+++ b/src/render.rs
@@ -123,7 +123,7 @@ pub(crate) fn render_findings(registry: &WorkflowRegistry, findings: &FindingReg
 }
 
 fn render_finding(registry: &WorkflowRegistry, finding: &Finding) {
-    let link = Link::new(finding.ident, &finding.url()).to_string();
+    let link = Link::new(finding.ident, &finding.url).to_string();
     let confidence = format!(
         "audit confidence → {:?}",
         &finding.determinations.confidence

--- a/src/render.rs
+++ b/src/render.rs
@@ -123,7 +123,7 @@ pub(crate) fn render_findings(registry: &WorkflowRegistry, findings: &FindingReg
 }
 
 fn render_finding(registry: &WorkflowRegistry, finding: &Finding) {
-    let link = Link::new(finding.ident, &finding.url).to_string();
+    let link = Link::new(finding.ident, finding.url).to_string();
     let confidence = format!(
         "audit confidence → {:?}",
         &finding.determinations.confidence


### PR DESCRIPTION
This adds the `Audit` supertrait, which can be quickly implemented for a type via the `audit_meta!(...)` macro.

This supertrait serves two purposes:

1. It allows us to do some deduplication/boilerplate reduction on individual audit trait impls;
2. It unlocks identity/context sharing between workflow audits and (to-be-implemented) action audits, since both can have `Audit` as a supertrait.