### PR TITLE
feat: adds new github-env audit

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -650,10 +650,12 @@ In general, users should use for [Github Actions environment files]
 
 [github-env.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/github-env.yml
 
-Detects dangerous usages of `$GITHUB_ENV` environment variable.
+Detects dangerous usages of the `GITHUB_ENV` environment variable.
 
-This audit compounds over `dangerous-triggers`: given the proper circumstances, an attacker
-may achieve code execution by controlling this environment variable.
+When used in workflows with dangerous triggers (such as `pull_request_target` and `workflow_run`), 
+`GITHUB_ENV` can be an arbitrary code execution risk. In particular, if the attacker is able to set
+arbitrary variables or variable contents via `GITHUB_ENV`, they made be able to set `LD_PRELOAD`
+or otherwise induce code execution implicitly within subsequent steps.
 
 Other resources:
 
@@ -662,9 +664,10 @@ Other resources:
 
 ### Remediation
 
-In general, you should avoid using `$GITHUB_ENV` when relying on dangerous Workflow triggers,
-especially for use cases like caching state or passing state around. For those, `$GITHUB_OUTPUT`
-may be an alternative.
+In general, you should avoid setting `GITHUB_ENV` within workflows that are attacker-triggered, 
+like `pull_request_target`.
+
+If you need to pass state between steps, consider using `GITHUB_OUTPUT` instead.
 
 
 [ArtiPACKED: Hacking Giants Through a Race Condition in GitHub Actions Artifacts]: https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -642,6 +642,31 @@ In general, users should use for [Github Actions environment files]
         echo "$HOME/.local/my-bin" >> "$GITHUB_PATH"
     ```
 
+## `github-env`
+
+| Type     | Examples           | Introduced in | Works offline  | Enabled by default |
+|----------|--------------------|---------------|----------------|--------------------|
+| Workflow  | [github-env.yml]   | v0.6.0        | ✅             | ✅                 |
+
+[github-env.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/github-env.yml
+
+Detects dangerous usages of `$GITHUB_ENV` environment variable.
+
+This audit compounds over `dangerous-triggers`: given the proper circumstances, an attacker
+may achieve code execution by controlling this environment variable.
+
+Other resources:
+
+* [GitHub Actions exploitation: environment manipulation]
+* [GHSL-2024-177: Environment Variable injection in an Actions workflow of Litestar]
+
+### Remediation
+
+In general, you should avoid using `$GITHUB_ENV` when relying on dangerous Workflow triggers,
+especially for use cases like caching state or passing state around. For those, `$GITHUB_OUTPUT`
+may be an alternative.
+
+
 [ArtiPACKED: Hacking Giants Through a Race Condition in GitHub Actions Artifacts]: https://unit42.paloaltonetworks.com/github-repo-artifacts-leak-tokens/
 [Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests]: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 [What the fork? Imposter commits in GitHub Actions and CI/CD]: https://www.chainguard.dev/unchained/what-the-fork-imposter-commits-in-github-actions-and-ci-cd
@@ -654,3 +679,5 @@ In general, users should use for [Github Actions environment files]
 [were deprecated by Github]: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
 [Github Actions environment files]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#environment-files
 [Semgrep audit]: https://semgrep.dev/r?q=yaml.github-actions.security.allowed-unsecure-commands.allowed-unsecure-commands
+[GitHub Actions exploitation: environment manipulation]: https://www.synacktiv.com/en/publications/github-actions-exploitation-repo-jacking-and-environment-manipulation
+[GHSL-2024-177: Environment Variable injection in an Actions workflow of Litestar]: https://securitylab.github.com/advisories/GHSL-2024-177_Litestar/

--- a/src/audit/dangerous_triggers.rs
+++ b/src/audit/dangerous_triggers.rs
@@ -15,7 +15,7 @@ audit_meta!(
 
 impl WorkflowAudit for DangerousTriggers {
     fn new(_: AuditState) -> Result<Self> {
-        Ok(Self {})
+        Ok(Self)
     }
 
     fn audit<'w>(&self, workflow: &'w Workflow) -> Result<Vec<Finding<'w>>> {

--- a/src/audit/dangerous_triggers.rs
+++ b/src/audit/dangerous_triggers.rs
@@ -1,37 +1,17 @@
 use anyhow::Result;
-use github_actions_models::workflow::event::{BareEvent, OptionalBody};
-use github_actions_models::workflow::Trigger;
 
 use super::{audit_meta, WorkflowAudit};
 use crate::finding::{Confidence, Finding, Severity};
 use crate::models::Workflow;
 use crate::state::AuditState;
 
-pub(crate) struct DangerousTriggers {}
+pub(crate) struct DangerousTriggers;
 
 audit_meta!(
     DangerousTriggers,
     "dangerous-triggers",
     "use of fundamentally insecure workflow trigger"
 );
-
-impl DangerousTriggers {
-    pub(crate) fn has_pull_request_target(&self, workflow: &Workflow) -> bool {
-        match &workflow.on {
-            Trigger::BareEvent(event) => *event == BareEvent::PullRequestTarget,
-            Trigger::BareEvents(events) => events.contains(&BareEvent::PullRequestTarget),
-            Trigger::Events(events) => !matches!(events.pull_request_target, OptionalBody::Missing),
-        }
-    }
-
-    pub(crate) fn has_workflow_run(&self, workflow: &Workflow) -> bool {
-        match &workflow.on {
-            Trigger::BareEvent(event) => *event == BareEvent::WorkflowRun,
-            Trigger::BareEvents(events) => events.contains(&BareEvent::WorkflowRun),
-            Trigger::Events(events) => !matches!(events.workflow_run, OptionalBody::Missing),
-        }
-    }
-}
 
 impl WorkflowAudit for DangerousTriggers {
     fn new(_: AuditState) -> Result<Self> {
@@ -40,7 +20,7 @@ impl WorkflowAudit for DangerousTriggers {
 
     fn audit<'w>(&self, workflow: &'w Workflow) -> Result<Vec<Finding<'w>>> {
         let mut findings = vec![];
-        if self.has_pull_request_target(workflow) {
+        if workflow.has_pull_request_target() {
             findings.push(
                 Self::finding()
                     .confidence(Confidence::Medium)
@@ -54,7 +34,7 @@ impl WorkflowAudit for DangerousTriggers {
                     .build(workflow)?,
             );
         }
-        if self.has_workflow_run(workflow) {
+        if workflow.has_workflow_run() {
             findings.push(
                 Self::finding()
                     .confidence(Confidence::Medium)

--- a/src/audit/dangerous_triggers.rs
+++ b/src/audit/dangerous_triggers.rs
@@ -7,9 +7,7 @@ use crate::finding::{Confidence, Finding, Severity};
 use crate::models::Workflow;
 use crate::state::AuditState;
 
-pub(crate) struct DangerousTriggers {
-    pub(crate) _state: AuditState,
-}
+pub(crate) struct DangerousTriggers {}
 
 audit_meta!(
     DangerousTriggers,
@@ -17,28 +15,32 @@ audit_meta!(
     "use of fundamentally insecure workflow trigger"
 );
 
-impl WorkflowAudit for DangerousTriggers {
-    fn new(state: AuditState) -> Result<Self> {
-        Ok(Self { _state: state })
-    }
-
-    fn audit<'w>(&self, workflow: &'w Workflow) -> Result<Vec<Finding<'w>>> {
-        let trigger = &workflow.on;
-
-        let has_pull_request_target = match trigger {
+impl DangerousTriggers {
+    pub(crate) fn has_pull_request_target(&self, workflow: &Workflow) -> bool {
+        match &workflow.on {
             Trigger::BareEvent(event) => *event == BareEvent::PullRequestTarget,
             Trigger::BareEvents(events) => events.contains(&BareEvent::PullRequestTarget),
             Trigger::Events(events) => !matches!(events.pull_request_target, OptionalBody::Missing),
-        };
+        }
+    }
 
-        let has_workflow_run = match trigger {
+    pub(crate) fn has_workflow_run(&self, workflow: &Workflow) -> bool {
+        match &workflow.on {
             Trigger::BareEvent(event) => *event == BareEvent::WorkflowRun,
             Trigger::BareEvents(events) => events.contains(&BareEvent::WorkflowRun),
             Trigger::Events(events) => !matches!(events.workflow_run, OptionalBody::Missing),
-        };
+        }
+    }
+}
 
+impl WorkflowAudit for DangerousTriggers {
+    fn new(_: AuditState) -> Result<Self> {
+        Ok(Self {})
+    }
+
+    fn audit<'w>(&self, workflow: &'w Workflow) -> Result<Vec<Finding<'w>>> {
         let mut findings = vec![];
-        if has_pull_request_target {
+        if self.has_pull_request_target(workflow) {
             findings.push(
                 Self::finding()
                     .confidence(Confidence::Medium)
@@ -52,7 +54,7 @@ impl WorkflowAudit for DangerousTriggers {
                     .build(workflow)?,
             );
         }
-        if has_workflow_run {
+        if self.has_workflow_run(workflow) {
             findings.push(
                 Self::finding()
                     .confidence(Confidence::Medium)

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -35,19 +35,21 @@ impl WorkflowAudit for GitHubEnv {
         let has_dangerous_triggers =
             workflow.has_workflow_run() || workflow.has_pull_request_target();
 
-        if has_dangerous_triggers {
-            if let StepBody::Run { run, .. } = &step.deref().body {
-                if self.uses_github_environment(run) {
-                    findings.push(
-                        Self::finding()
-                            .severity(Severity::High)
-                            .confidence(Confidence::Low)
-                            .add_location(step.location().with_keys(&["run".into()]).annotated(
-                                "GITHUB_ENV used in the context of a dangerous Workflow trigger",
-                            ))
-                            .build(step.workflow())?,
-                    )
-                }
+        if !has_dangerous_triggers {
+            return Ok(findings);
+        }
+
+        if let StepBody::Run { run, .. } = &step.deref().body {
+            if self.uses_github_environment(run) {
+                findings.push(
+                    Self::finding()
+                        .severity(Severity::High)
+                        .confidence(Confidence::Low)
+                        .add_location(step.location().with_keys(&["run".into()]).annotated(
+                            "GITHUB_ENV used in the context of a dangerous Workflow trigger",
+                        ))
+                        .build(step.workflow())?,
+                )
             }
         }
 

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -1,0 +1,49 @@
+use super::{audit_meta, WorkflowAudit};
+use crate::audit::dangerous_triggers::DangerousTriggers;
+use crate::finding::{Confidence, Finding, Severity};
+use crate::models::Step;
+use crate::state::AuditState;
+use github_actions_models::workflow::job::StepBody;
+use std::ops::Deref;
+
+pub(crate) struct GitHubEnv;
+
+audit_meta!(GitHubEnv, "github-env", "dangerous use of $GITHUB_ENV");
+
+impl WorkflowAudit for GitHubEnv {
+    fn new(_: AuditState) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self {})
+    }
+
+    fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+        let mut findings = vec![];
+
+        let workflow = step.workflow();
+
+        let dangerous_triggers_detector = DangerousTriggers {};
+
+        let has_dangerous_triggers = dangerous_triggers_detector.has_workflow_run(workflow)
+            || dangerous_triggers_detector.has_pull_request_target(workflow);
+
+        if has_dangerous_triggers {
+            if let StepBody::Run { run, .. } = &step.deref().body {
+                if run.contains("$GITHUB_ENV") {
+                    findings.push(
+                        Self::finding()
+                            .severity(Severity::High)
+                            .confidence(Confidence::High)
+                            .add_location(step.location().with_keys(&["run".into()]).annotated(
+                                "GITHUB_ENV used in the context of a dangerous Workflow trigger",
+                            ))
+                            .build(step.workflow())?,
+                    )
+                }
+            }
+        }
+
+        Ok(findings)
+    }
+}

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -12,7 +12,7 @@ audit_meta!(GitHubEnv, "github-env", "dangerous use of $GITHUB_ENV");
 impl GitHubEnv {
     fn uses_github_environment(&self, run_step_body: &str) -> bool {
         // In the future we can improve over this implementation,
-        // eventually detecting how $GITHUB_ENV has being used
+        // eventually detecting how $GITHUB_ENV is being used
         // and returning an Option<Confidence> instead
 
         run_step_body.contains("$GITHUB_ENV") || run_step_body.contains("${GITHUB_ENV}")

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -24,7 +24,7 @@ impl WorkflowAudit for GitHubEnv {
     where
         Self: Sized,
     {
-        Ok(Self {})
+        Ok(Self)
     }
 
     fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 pub(crate) mod artipacked;
 pub(crate) mod dangerous_triggers;
 pub(crate) mod excessive_permissions;
+pub(crate) mod github_env;
 pub(crate) mod hardcoded_container_credentials;
 pub(crate) mod impostor_commit;
 pub(crate) mod insecure_commands;

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,6 +161,7 @@ fn run() -> Result<ExitCode> {
     register_audit!(audit::known_vulnerable_actions::KnownVulnerableActions);
     register_audit!(audit::unpinned_uses::UnpinnedUses);
     register_audit!(audit::insecure_commands::InsecureCommands);
+    register_audit!(audit::github_env::GitHubEnv);
 
     let bar = ProgressBar::new((workflow_registry.len() * audit_registry.len()) as u64);
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -76,6 +76,7 @@ impl Workflow {
         Jobs::new(self)
     }
 
+    /// Whether this workflow's is triggered by pull_request_target.
     pub(crate) fn has_pull_request_target(&self) -> bool {
         match &self.on {
             Trigger::BareEvent(event) => *event == BareEvent::PullRequestTarget,
@@ -84,6 +85,7 @@ impl Workflow {
         }
     }
 
+    /// Whether this workflow's is triggered by workflow_run.
     pub(crate) fn has_workflow_run(&self) -> bool {
         match &self.on {
             Trigger::BareEvent(event) => *event == BareEvent::WorkflowRun,

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,13 +3,14 @@
 
 use std::{collections::hash_map, iter::Enumerate, ops::Deref, path::Path};
 
+use crate::finding::{Route, SymbolicLocation};
 use anyhow::{anyhow, Context, Result};
+use github_actions_models::workflow::event::{BareEvent, OptionalBody};
 use github_actions_models::workflow::{
     self,
     job::{NormalJob, StepBody},
+    Trigger,
 };
-
-use crate::finding::{Route, SymbolicLocation};
 
 /// Represents an entire GitHub Actions workflow.
 ///
@@ -73,6 +74,22 @@ impl Workflow {
     /// A [`Jobs`] iterator over this workflow's constituent [`Job`]s.
     pub(crate) fn jobs(&self) -> Jobs<'_> {
         Jobs::new(self)
+    }
+
+    pub(crate) fn has_pull_request_target(&self) -> bool {
+        match &self.on {
+            Trigger::BareEvent(event) => *event == BareEvent::PullRequestTarget,
+            Trigger::BareEvents(events) => events.contains(&BareEvent::PullRequestTarget),
+            Trigger::Events(events) => !matches!(events.pull_request_target, OptionalBody::Missing),
+        }
+    }
+
+    pub(crate) fn has_workflow_run(&self) -> bool {
+        match &self.on {
+            Trigger::BareEvent(event) => *event == BareEvent::WorkflowRun,
+            Trigger::BareEvents(events) => events.contains(&BareEvent::WorkflowRun),
+            Trigger::Events(events) => !matches!(events.workflow_run, OptionalBody::Missing),
+        }
     }
 }
 

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -252,9 +252,7 @@ fn audit_github_env_injection() -> anyhow::Result<()> {
 
     let findings = serde_json::from_slice(&execution.stdout)?;
 
-    println!("{:#?}", findings);
-
-    assert_value_match(&findings, "$[0].determinations.confidence", "High");
+    assert_value_match(&findings, "$[0].determinations.confidence", "Low");
     assert_value_match(
         &findings,
         "$[0].locations[0].concrete.feature",

--- a/tests/test-data/github_env.yml
+++ b/tests/test-data/github_env.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+
+jobs:
+  vulnerable:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Passes the title around
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          message=$(echo "$TITLE" | grep -oP '[{\[][^}\]]+[}\]]' | sed 's/{\|}\|\[\|\]//g')
+          echo "message=$message" >> $GITHUB_ENV


### PR DESCRIPTION
- Pulls dangerous triggers detection logic from `WorkflowAudit` and moves to `impl DangerousTriggers` instance methods
- Reuses only that logic in the context of to implement a new audit

```bash
cargo run -- tests/test-data/github_env.yml

error[github-env]: dangerous use of $GITHUB_ENV
  --> tests/test-data/github_env.yml:12:9
   |
12 |           run: |
   |  _________^
13 | |           message=$(echo "$TITLE" | grep -oP '[{\[][^}\]]+[}\]]' | sed 's/{\|}\|\[\|\]//g')
14 | |           echo "message=$message" >> $GITHUB_ENV
   | |_________________________________________________^ GITHUB_ENV used in the context of a dangerous Workflow trigger
   |
   = note: audit confidence → High

2 findings (1 ignored): 0 unknown, 0 informational, 0 low, 0 medium, 1 high
```

Some questions below!