### PR TITLE
feat: add `--min-severity`

### DIFF
--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -6,15 +6,16 @@ Arguments:
   <INPUTS>...  The workflow filenames or directories to audit
 
 Options:
-  -p, --pedantic             Emit findings even when the context suggests an explicit security decision made by the user
-  -o, --offline              Only perform audits that don't require network access
-  -v, --verbose...           Increase logging verbosity
-  -q, --quiet...             Decrease logging verbosity
-  -n, --no-progress          Disable the progress bar. This is useful primarily when running with a high verbosity level, as the two will fight for stderr
-      --gh-token <GH_TOKEN>  The GitHub API token to use [env: GH_TOKEN=]
-      --format <FORMAT>      The output format to emit. By default, plain text will be emitted [possible values: plain, json, sarif]
-  -c, --config <CONFIG>      The configuration file to load. By default, any config will be discovered relative to $CWD
-      --no-config            Disable all configuration loading
-      --no-exit-codes        Disable all error codes besides success and tool failure
-  -h, --help                 Print help
-  -V, --version              Print version
+  -p, --pedantic                     Emit findings even when the context suggests an explicit security decision made by the user
+  -o, --offline                      Only perform audits that don't require network access
+  -v, --verbose...                   Increase logging verbosity
+  -q, --quiet...                     Decrease logging verbosity
+  -n, --no-progress                  Disable the progress bar. This is useful primarily when running with a high verbosity level, as the two will fight for stderr
+      --gh-token <GH_TOKEN>          The GitHub API token to use [env: GH_TOKEN=]
+      --format <FORMAT>              The output format to emit. By default, plain text will be emitted [possible values: plain, json, sarif]
+  -c, --config <CONFIG>              The configuration file to load. By default, any config will be discovered relative to $CWD
+      --no-config                    Disable all configuration loading
+      --no-exit-codes                Disable all error codes besides success and tool failure
+      --min-severity <MIN_SEVERITY>  Filter all results below this severity [possible values: unknown, informational, low, medium, high]
+  -h, --help                         Print help
+  -V, --version                      Print version

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -65,6 +65,33 @@ See [Integration](#integration) for suggestions on when to use each format.
 
 All other exit codes are currently reserved.
 
+## Filtering results
+
+There are two straightforward ways to filter `zizmor`'s results:
+
+1. If all you need is severity filtering (e.g. "I want only medium-severity
+   and above results"), then you can use the `--min-severity` flag:
+
+    !!! tip
+
+        `--min-severity` is available in `v0.6.0` and later.
+
+     ```bash
+     # filter unknown, informational, and low findings
+     zizmor --min-severity=medium ...
+     ```
+
+2. If you need more advanced filtering (with nontrivial conditions or
+   state considerations), then consider using `--format=json` and using
+   `jq` (or a script) to perform your filtering.
+
+     As a starting point, here's how you can use `jq` to filter `zizmor`'s
+     JSON output to only results that are marked as "high confidence":
+
+     ```bash
+     zizmor --format=json ... | jq 'map(select(.determinations.confidence == "High"))'
+     ```
+
 ## Ignoring results
 
 `zizmor`'s defaults are not always 100% right for every possible use case.

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -3,6 +3,7 @@
 use std::borrow::Cow;
 
 use anyhow::Result;
+use clap::ValueEnum;
 use locate::Locator;
 use serde::Serialize;
 use terminal_link::Link;
@@ -13,7 +14,7 @@ pub(crate) mod locate;
 
 // TODO: Traits + more flexible models here.
 
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, ValueEnum)]
 pub(crate) enum Confidence {
     #[default]
     Unknown,
@@ -22,7 +23,9 @@ pub(crate) enum Confidence {
     High,
 }
 
-#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialOrd, PartialEq, Serialize)]
+#[derive(
+    Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialOrd, PartialEq, Serialize, ValueEnum,
+)]
 pub(crate) enum Severity {
     #[default]
     Unknown,


### PR DESCRIPTION
This adds `--min-severity`, which can be given
a severity level to filter any findings below
that level.

For example:

```
zizmor --min-severity=high
```

will filter any findings below "high," i.e."
findings at unknown, informational, low,
or medium.

Closes #60.