### PR TITLE
docs: add page descriptions

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1,3 +1,7 @@
+---
+description: Audit rules, examples, and remediations.
+---
+
 # Audit Rules
 
 This page documents each of the audits currently implemented in `zizmor`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,3 +1,7 @@
+---
+description: zizmor's configuration file and configurable behaviors.
+---
+
 # Configuration
 
 !!! note

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,7 @@
+---
+description: Development tasks and processes.
+---
+
 # Hacking on `zizmor`
 
 !!! important

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,8 @@
-# Installation
+---
+description: Installation instructions for zizmor.
+---
 
+# Installation
 
 ## From crates.io
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,3 +1,7 @@
+---
+description: Usage recipes for running zizmor locally and in CI/CD.
+---
+
 # Usage Recipes
 
 ## Operating Modes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 strict: true
 site_name: "zizmor"
-# site_description: zizmor
+site_description: Static analysis for GitHub Actions
 site_url: https://woodruffw.github.io/zizmor
 docs_dir: docs
 site_dir: site_html


### PR DESCRIPTION
These enrich the metadata and social cards
slightly. Not all pages have custom descriptions,
since the site-wide `site_description` is adequate in some cases.

See #79.