### PR TITLE
feat: improve precision for github-env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "pretty_assertions",
+ "regex",
  "reqwest",
  "serde",
  "serde-sarif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ moka = { version = "0.12.8", features = ["sync"] }
 owo-colors = "4.1.0"
 pest = "2.7.14"
 pest_derive = "2.7.14"
+regex = "1.11.1"
 reqwest = { version = "0.12.9", features = ["blocking", "json"] }
 serde = { version = "1.0.215", features = ["derive"] }
 serde-sarif = "0.6.5"

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 use std::sync::LazyLock;
 
 static GITHUB_ENV_WRITE_SHELL: LazyLock<RegexSet> = LazyLock::new(|| {
-    RegexSet::new(&[
+    RegexSet::new([
         // matches the `... >> $GITHUB_ENV` pattern
         r#"(?m)^.+\s*>>?\s*"?\$\{?GITHUB_ENV\}?"?.*$"#,
         // matches the `... | tee $GITHUB_ENV` pattern


### PR DESCRIPTION
Per #197 -- this improves our precision by only matching things that resemble writes to `$GITHUB_ENV`, e.g. `... >> $GITHUB_ENV`.

There are probably other patterns we should detect, and this is still very primitive. Longer term, we need to perform some degree of actual parsing here.