### PR TITLE
Split unpinned-uses into two separate checks

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -544,6 +544,9 @@ GitHub Actions will use the latest commit on the referenced repository
 This can represent a (small) security risk, as it leaves the calling workflow
 at the mercy of the callee action's default branch.
 
+`uses:` clauses with no pin are flagged as *Medium* severity. `uses:` clauses
+with a branch or tag pin are flagged as *Low* severity.
+
 ### Remediation
 
 For repository actions (like @actions/checkout): add a branch, tag, or SHA

--- a/src/models.rs
+++ b/src/models.rs
@@ -433,6 +433,13 @@ impl<'a> Uses<'a> {
             Uses::Repository(repo) => repo.git_ref.is_none(),
         }
     }
+
+    pub(crate) fn unhashed(&self) -> bool {
+        match self {
+            Uses::Docker(docker) => docker.hash.is_some(),
+            Uses::Repository(repo) => !repo.ref_is_commit(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -67,7 +67,7 @@ fn audit_artipacked() -> anyhow::Result<()> {
     assert_value_match(
         &findings,
         "$[0].locations[0].concrete.feature",
-        "uses: actions/checkout@v4",
+        "uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
     );
 
     Ok(())
@@ -188,12 +188,12 @@ fn audit_unpinned_uses() -> anyhow::Result<()> {
 
     let execution = zizmor().args(cli_args).output()?;
 
-    assert_eq!(execution.status.code(), Some(11));
+    assert_eq!(execution.status.code(), Some(13));
 
     let findings = serde_json::from_slice(&execution.stdout)?;
 
     assert_value_match(&findings, "$[0].determinations.confidence", "High");
-    assert_value_match(&findings, "$[0].determinations.severity", "Informational");
+    assert_value_match(&findings, "$[0].determinations.severity", "Medium");
     assert_value_match(
         &findings,
         "$[0].locations[0].concrete.feature",

--- a/tests/test-data/artipacked.yml
+++ b/tests/test-data/artipacked.yml
@@ -10,4 +10,4 @@ jobs:
   artipacked:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2

--- a/tests/test-data/inlined-ignores.yml
+++ b/tests/test-data/inlined-ignores.yml
@@ -8,7 +8,7 @@ jobs:
   artipacked-ignored:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # zizmor: ignore[artipacked]
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
 
   insecure-commands-ignored:
     runs-on: ubuntu-latest
@@ -26,3 +26,8 @@ jobs:
         password: hackme # zizmor: ignore[hardcoded-container-credentials]
     steps:
       - run: echo 'This is a honeypot actually!'
+
+  unpinned-uses-ignored:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/codeql-action/upload-sarif # zizmor: ignore[unpinned-uses]

--- a/tests/test-data/template-injection.yml
+++ b/tests/test-data/template-injection.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # tag=v7.0.1
         with:
           script: |
             return "doing a thing: ${{ github.event.issue.title }}"

--- a/tests/test-data/use-trusted-publishing.yml
+++ b/tests/test-data/use-trusted-publishing.yml
@@ -10,6 +10,6 @@ jobs:
       id-token: write
     steps:
       - name: vulnerable-2
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@release/v1 # zizmor: ignore[unpinned-uses]
         with:
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Here's my first pass at implementing #179. The code is there and functional, AFAICT. I've tested it against a real workflow file that uses repo paths. I don't have any handy that use Docker, but if I understand the model correctly, it's very straightforward to check it and so my code will Just Work™.

~~I will add tests and docs before I remove the "WIP" from this, but I wanted to make sure what I've done here is generally acceptable before I put effort into that part.~~

~~Since most of the "what to do if we find an unpinned `uses` of either flavor" is repetitive, I tossed in a flag instead of repeating that code.~~

There's a lot of "not" in the new function I created in the model. It could have been written a little more cleanly without the negations, but that kept the usage the same as in the existing `unpinned()`, which seemed more important.

Of note, this only looks to see if the pin _looks like_ a SHA. It does not attempt to verify that such a SHA actually exists. You probably expect that, but I wanted to be explicit about it (and I will be in the docs updates, when I create them)

~~Edit to add: I have also not run fmt or clippy yet, since it seemed like something that could wait until I got a thumbs up on the general direction.~~

Fixes #179 