### PR TITLE
feat: unpinned-uses: make unhashed check pedantic for now

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -544,8 +544,9 @@ GitHub Actions will use the latest commit on the referenced repository
 This can represent a (small) security risk, as it leaves the calling workflow
 at the mercy of the callee action's default branch.
 
-`uses:` clauses with no pin are flagged as *Medium* severity. `uses:` clauses
-with a branch or tag pin are flagged as *Low* severity.
+When used with `--pedantic`, this audit will also flag pinned-but-unhashed
+`uses:`. For example, `actions/checkout@v4` will not be flagged by default,
+but would be flagged with `--pedantic`.
 
 ### Remediation
 


### PR DESCRIPTION
Makes the pinned-but-unhashed check `--pedantic`-only for now, since I'm still working out how to model sensitivities/auditing personas.

Signed-off-by: William Woodruff <william@yossarian.net>