### PR TITLE
feat: remote auditing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2584,7 @@ dependencies = [
  "anstream",
  "anyhow",
  "assert_cmd",
+ "camino",
  "clap",
  "clap-verbosity-flag",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.80.1"
 annotate-snippets = "0.11.4"
 anstream = "0.6.18"
 anyhow = "1.0.93"
+camino = { version = "1.1.9", features = ["serde1"] }
 clap = { version = "4.5.21", features = ["derive", "env"] }
 clap-verbosity-flag = "3.0.0"
 env_logger = "0.11.5"

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ $(VENV): site-requirements.txt
 
 .PHONY: snippets
 snippets:
-	cargo run -- --help > docs/snippets/help.txt
+	cargo run -- -h > docs/snippets/help.txt

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-First, run `zizmor --help` to make sure your installation succeeded.
+First, run `zizmor -h` to make sure your installation succeeded.
 
 You should see something like this:
 
@@ -8,30 +8,66 @@ You should see something like this:
 --8<-- "help.txt"
 ```
 
+!!! tip
+
+    Run `zizmor --help` for a longer and more detailed version of `zizmor -h`.
+
 ## Running `zizmor`
 
-You can run `zizmor` on any file(s) you have locally:
+Here are some different ways you can run `zizmor` locally:
 
-```bash
-# audit a specific workflow
-zizmor my-workflow.yml
-# discovers .github/workflows/*.yml automatically
-zizmor path/to/repo
-```
+=== "On one or more files"
 
-By default, `zizmor` will emit Rust-style diagnostics, e.g.:
+    You can run `zizmor` on one or more workflows as explicit inputs:
 
-```console
-error[pull-request-target]: use of fundamentally insecure workflow trigger
-  --> /home/william/devel/gha-hazmat/.github/workflows/pull-request-target.yml:20:1
-   |
-20 | / on:
-21 | |   # NOT OK: pull_request_target should almost never be used
-22 | |   pull_request_target:
-   | |______________________^ triggers include pull_request_target, which is almost always used insecurely
-   |
+    ```bash
+    zizmor ci.yml tests.yml lint.yml
+    ```
 
-1 findings (0 unknown, 0 informational, 0 low, 0 medium, 1 high)
-```
+    These can be in any directory as well:
+
+    ```
+    zizmor ./subdir/ci.yml ../sibling/tests.yml
+    ```
+
+=== "On one or more directories"
+
+    If you have multiple workflows in a single directory, `zizmor` will
+    discover them:
+
+    ```bash
+    # somewhere/ contains ci.yml and tests.yml
+    zizmor somewhere/
+    ```
+
+    Moreover, if the specified directory contains a `.github/workflows`
+    subdirectory, `zizmor` will discover workflows there:
+
+    ```bash
+    # my-local-repo/ contains .github/workflows/{ci,tests}.yml
+    zizmor my-local-repo/
+    ```
+
+=== "On one or more remote repositories"
+
+    !!! tip
+
+        Private repositories can also be audited remotely, as long
+        as your GitHub API token has sufficient permissions.
+
+    `zizmor` can also fetch workflows directly from GitHub, if given a
+    GitHub API token via `GH_TOKEN` or `--gh-token`:
+
+    ```bash
+    # audit all workflows in woodruffw/zizmor
+    # assumes you have `gh` installed
+    zizmor --gh-token=$(gh auth token) woodruffw/zizmor
+    ```
+
+    Multiple repositories will also work:
+
+    ```bash
+    zizmor --gh-token=$(gh auth token) woodruffw/zizmor woodruffw/gha-hazmat
+    ```
 
 See [Usage](./usage.md) for more examples, including examples of configuration.

--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -25,9 +25,23 @@ Options:
           - regular:  The "regular" persona (minimal false positives)
 
   -o, --offline
+          Perform only offline operations.
+          
+          This disables all online audit rules, and prevents zizmor from auditing remote repositories.
+          
+          [env: ZIZMOR_OFFLINE=]
+
+      --gh-token <GH_TOKEN>
+          The GitHub API token to use
+          
+          [env: GH_TOKEN=]
+
+      --no-online-audits
           Perform only offline audits.
           
-          This flag affects only audits, and not other potentially online operations (like auditing from a GitHub user/repo slug).
+          This is a weaker version of `--offline`: instead of completely forbidding all online operations, it only disables audits that require connectivity.
+          
+          [env: ZIZMOR_NO_ONLINE_AUDITS=]
 
   -v, --verbose...
           Increase logging verbosity
@@ -37,11 +51,6 @@ Options:
 
   -n, --no-progress
           Disable the progress bar. This is useful primarily when running with a high verbosity level, as the two will fight for stderr
-
-      --gh-token <GH_TOKEN>
-          The GitHub API token to use
-          
-          [env: GH_TOKEN=]
 
       --format <FORMAT>
           The output format to emit. By default, plain text will be emitted

--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -4,7 +4,9 @@ Usage: zizmor [OPTIONS] <INPUTS>...
 
 Arguments:
   <INPUTS>...
-          The workflow filenames or directories to audit
+          The inputs to audit.
+          
+          These can be individual workflow filenames, entire directories, or a `user/repo` slug for a GitHub repository. In the latter case, a `@ref` can be appended to audit the repository at a particular git reference state.
 
 Options:
   -p, --pedantic

--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -3,82 +3,38 @@ Static analysis for GitHub Actions
 Usage: zizmor [OPTIONS] <INPUTS>...
 
 Arguments:
-  <INPUTS>...
-          The inputs to audit.
-          
-          These can be individual workflow filenames, entire directories, or a `user/repo` slug for a GitHub repository. In the latter case, a `@ref` can be appended to audit the repository at a particular git reference state.
+  <INPUTS>...  The inputs to audit
 
 Options:
   -p, --pedantic
-          Emit 'pedantic' findings.
-          
-          This is an alias for --persona=pedantic.
-
+          Emit 'pedantic' findings
       --persona <PERSONA>
-          The persona to use while auditing
-          
-          [default: regular]
-
-          Possible values:
-          - auditor:  The "auditor" persona (false positives OK)
-          - pedantic: The "pedantic" persona (code smells OK)
-          - regular:  The "regular" persona (minimal false positives)
-
+          The persona to use while auditing [default: regular] [possible values: auditor, pedantic, regular]
   -o, --offline
-          Perform only offline operations.
-          
-          This disables all online audit rules, and prevents zizmor from auditing remote repositories.
-          
-          [env: ZIZMOR_OFFLINE=]
-
+          Perform only offline operations [env: ZIZMOR_OFFLINE=]
       --gh-token <GH_TOKEN>
-          The GitHub API token to use
-          
-          [env: GH_TOKEN=]
-
+          The GitHub API token to use [env: GH_TOKEN=]
       --no-online-audits
-          Perform only offline audits.
-          
-          This is a weaker version of `--offline`: instead of completely forbidding all online operations, it only disables audits that require connectivity.
-          
-          [env: ZIZMOR_NO_ONLINE_AUDITS=]
-
+          Perform only offline audits [env: ZIZMOR_NO_ONLINE_AUDITS=]
   -v, --verbose...
           Increase logging verbosity
-
   -q, --quiet...
           Decrease logging verbosity
-
   -n, --no-progress
           Disable the progress bar. This is useful primarily when running with a high verbosity level, as the two will fight for stderr
-
       --format <FORMAT>
-          The output format to emit. By default, plain text will be emitted
-          
-          [default: plain]
-          [possible values: plain, json, sarif]
-
+          The output format to emit. By default, plain text will be emitted [default: plain] [possible values: plain, json, sarif]
   -c, --config <CONFIG>
           The configuration file to load. By default, any config will be discovered relative to $CWD
-
       --no-config
           Disable all configuration loading
-
       --no-exit-codes
           Disable all error codes besides success and tool failure
-
       --min-severity <MIN_SEVERITY>
-          Filter all results below this severity
-          
-          [possible values: unknown, informational, low, medium, high]
-
+          Filter all results below this severity [possible values: unknown, informational, low, medium, high]
       --min-confidence <MIN_CONFIDENCE>
-          Filter all results below this confidence
-          
-          [possible values: unknown, low, medium, high]
-
+          Filter all results below this confidence [possible values: unknown, low, medium, high]
   -h, --help
-          Print help (see a summary with '-h')
-
+          Print help (see more with '--help')
   -V, --version
           Print version

--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -23,7 +23,9 @@ Options:
           - regular:  The "regular" persona (minimal false positives)
 
   -o, --offline
-          Only perform audits that don't require network access
+          Perform only offline audits.
+          
+          This flag affects only audits, and not other potentially online operations (like auditing from a GitHub user/repo slug).
 
   -v, --verbose...
           Increase logging verbosity

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -322,7 +322,7 @@ jobs:
 1. Optional: Remove the `env:` block to only run `zizmor`'s offline audits.
 
 For more inspiration, see `zizmor`'s own [repository workflow scan], as well
-as  GitHub's example of [running ESLint] as a security workflow.
+as GitHub's example of [running ESLint] as a security workflow.
 
 [SARIF]: https://sarifweb.azurewebsites.net/
 
@@ -341,7 +341,7 @@ To do so, add the following to your `.pre-commit-config.yaml` `repos` section:
 
 ```yaml
 -   repo: https://github.com/woodruffw/zizmor
-    rev: v0.3.0 # (1)!
+    rev: v0.7.0 # (1)!
     hooks:
     - id: zizmor
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,10 +15,15 @@ Both of these can be made explicit through their respective command-line flags:
 
 ```bash
 # force offline, even if a GH_TOKEN is present
+# this disables all online actions, including repository fetches
 zizmor --offline workflow.yml
 
-# passing a token explicitly will forcefully enable online mode
+# passing a token explicitly will enable online mode
 zizmor --gh-token ghp-... workflow.yml
+
+# online for the purpose of fetching the input (example/example),
+# but all audits themselves are offline
+zizmor --no-online-audits --gh-token ghp-... example/example
 ```
 
 ## Output formats

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -172,7 +172,7 @@ mod tests {
             ("something | tee \"${$OTHER_ENV}\" # not $GITHUB_ENV", false),
         ] {
             let audit_state = AuditState {
-                offline: false,
+                no_online_audits: false,
                 gh_token: None,
                 caches: Caches::new(),
             };

--- a/src/audit/impostor_commit.rs
+++ b/src/audit/impostor_commit.rs
@@ -116,7 +116,7 @@ impl ImpostorCommit {
 
 impl WorkflowAudit for ImpostorCommit {
     fn new(state: AuditState) -> Result<Self> {
-        if state.offline {
+        if state.no_online_audits {
             return Err(anyhow!("offline audits only requested"));
         }
 

--- a/src/audit/known_vulnerable_actions.rs
+++ b/src/audit/known_vulnerable_actions.rs
@@ -125,7 +125,7 @@ impl WorkflowAudit for KnownVulnerableActions {
     where
         Self: Sized,
     {
-        if state.offline {
+        if state.no_online_audits {
             return Err(anyhow!("offline audits only requested"));
         }
 

--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -61,7 +61,7 @@ impl WorkflowAudit for RefConfusion {
     where
         Self: Sized,
     {
-        if state.offline {
+        if state.no_online_audits {
             return Err(anyhow!("offline audits only requested"));
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,7 +123,10 @@ impl Config {
         // multiple files, as the first location is the one a user will
         // typically ignore, suppressing the rest in the process.
         for loc in &finding.locations {
-            for rule in ignores.iter().filter(|i| i.filename == loc.symbolic.name) {
+            for rule in ignores
+                .iter()
+                .filter(|i| i.filename == loc.symbolic.key.filename())
+            {
                 match rule {
                     // Rule has a line and (maybe) a column.
                     WorkflowRule {

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -142,7 +142,7 @@ pub(crate) struct SymbolicLocation<'w> {
 impl<'w> SymbolicLocation<'w> {
     pub(crate) fn with_keys(&self, keys: &[RouteComponent<'w>]) -> SymbolicLocation<'w> {
         SymbolicLocation {
-            key: &self.key,
+            key: self.key,
             annotation: self.annotation.clone(),
             link: None,
             route: self.route.with_keys(keys),

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -9,7 +9,10 @@ use regex::Regex;
 use serde::Serialize;
 use terminal_link::Link;
 
-use crate::models::{Job, Step, Workflow};
+use crate::{
+    models::{Job, Step, Workflow},
+    registry::WorkflowKey,
+};
 
 pub(crate) mod locate;
 
@@ -120,8 +123,8 @@ impl<'w> Route<'w> {
 /// Represents a symbolic workflow location.
 #[derive(Serialize, Clone, Debug)]
 pub(crate) struct SymbolicLocation<'w> {
-    /// The name of the workflow, as it appears in the workflow registry.
-    pub(crate) name: &'w str,
+    /// The unique ID of the workflow, as it appears in the workflow registry.
+    pub(crate) key: &'w WorkflowKey,
 
     /// An annotation for this location.
     pub(crate) annotation: String,
@@ -139,7 +142,7 @@ pub(crate) struct SymbolicLocation<'w> {
 impl<'w> SymbolicLocation<'w> {
     pub(crate) fn with_keys(&self, keys: &[RouteComponent<'w>]) -> SymbolicLocation<'w> {
         SymbolicLocation {
-            name: self.name,
+            key: &self.key,
             annotation: self.annotation.clone(),
             link: None,
             route: self.route.with_keys(keys),

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -206,11 +206,14 @@ impl Client {
     ) -> Result<Vec<Workflow>> {
         log::debug!("fetching workflows for {owner}/{repo}");
 
+        // It'd be nice if the GitHub contents API allowed us to retrieve
+        // all file contents with a directory listing, but it doesn't.
+        // Instead, we make `N+1` API calls: one to list the workflows
+        // directory, and `N` for the constituent workflow files.
         let url = format!(
             "{api_base}/repos/{owner}/{repo}/contents/.github/workflows",
             api_base = self.api_base
         );
-
         let resp: Vec<File> = self
             .http
             .get(&url)

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,12 +40,24 @@ struct App {
     #[arg(long, group = "_persona", value_enum, default_value_t)]
     persona: Persona,
 
+    /// Perform only offline operations.
+    ///
+    /// This disables all online audit rules, and prevents zizmor from
+    /// auditing remote repositories.
+    #[arg(short, long, env = "ZIZMOR_OFFLINE", group = "_offline")]
+    offline: bool,
+
+    /// The GitHub API token to use.
+    #[arg(long, env, group = "_offline")]
+    gh_token: Option<String>,
+
     /// Perform only offline audits.
     ///
-    /// This flag affects only audits, and not other potentially
-    /// online operations (like auditing from a GitHub user/repo slug).
-    #[arg(short, long)]
-    offline: bool,
+    /// This is a weaker version of `--offline`: instead of completely
+    /// forbidding all online operations, it only disables audits that
+    /// require connectivity.
+    #[arg(long, env = "ZIZMOR_NO_ONLINE_AUDITS")]
+    no_online_audits: bool,
 
     #[command(flatten)]
     verbose: clap_verbosity_flag::Verbosity,
@@ -54,10 +66,6 @@ struct App {
     /// with a high verbosity level, as the two will fight for stderr.
     #[arg(short, long)]
     no_progress: bool,
-
-    /// The GitHub API token to use.
-    #[arg(long, env)]
-    gh_token: Option<String>,
 
     /// The output format to emit. By default, plain text will be emitted
     #[arg(long, value_enum, default_value_t)]
@@ -187,7 +195,7 @@ fn run() -> Result<ExitCode> {
                     format!(
                         "try removing {offline} or passing {gh_token}",
                         offline = "--offline".yellow(),
-                        gh_token = "--gh-token <TOKEN>".yellow()
+                        gh_token = "--gh-token <TOKEN>".yellow(),
                     )
                 ))
             })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,7 @@ fn run() -> Result<ExitCode> {
                 match workflow_path.extension() {
                     Some(ext) if ext == "yml" || ext == "yaml" => {
                         workflow_registry
-                            .register_by_path(&workflow_path)
+                            .register_by_path(workflow_path)
                             .with_context(|| {
                                 format!("failed to register workflow: {workflow_path}")
                             })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ fn run() -> Result<ExitCode> {
             // Our pre-existing `uses: <slug>` parser does 90% of the work for us.
             let Some(Uses::Repository(slug)) = Uses::from_step(input) else {
                 return Err(anyhow!(tip(
-                    format!("malformed input: {input}"),
+                    format!("invalid input: {input}"),
                     format!(
                         "pass a single {file}, {directory}, or entire repo by {slug} slug",
                         file = "file".green(),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -292,3 +292,36 @@ impl From<FindingRegistry<'_>> for ExitCode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::models::Uses;
+
+    use super::WorkflowKey;
+
+    #[test]
+    fn test_workflow_key_display() {
+        let local = WorkflowKey::local("/foo/bar/baz.yml".into()).unwrap();
+        assert_eq!(local.to_string(), "file:///foo/bar/baz.yml");
+
+        // No ref
+        let Uses::Repository(slug) = Uses::from_step("foo/bar").unwrap() else {
+            panic!()
+        };
+        let remote = WorkflowKey::remote(&slug, ".github/workflows/baz.yml".into()).unwrap();
+        assert_eq!(
+            remote.to_string(),
+            "https://github.com/foo/bar/blob/HEAD/.github/workflows/baz.yml"
+        );
+
+        // With a git ref
+        let Uses::Repository(slug) = Uses::from_step("foo/bar@v1").unwrap() else {
+            panic!()
+        };
+        let remote = WorkflowKey::remote(&slug, ".github/workflows/baz.yml".into()).unwrap();
+        assert_eq!(
+            remote.to_string(),
+            "https://github.com/foo/bar/blob/v1/.github/workflows/baz.yml"
+        );
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,7 +1,7 @@
 //! Functionality for registering and managing the lifecycles of
 //! audits.
 
-use std::{collections::HashMap, fmt::Display, process::ExitCode};
+use std::{fmt::Display, process::ExitCode};
 
 use crate::{
     audit::WorkflowAudit,
@@ -12,6 +12,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
+use indexmap::IndexMap;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize)]
@@ -103,7 +104,7 @@ impl WorkflowKey {
 }
 
 pub(crate) struct WorkflowRegistry {
-    pub(crate) workflows: HashMap<WorkflowKey, Workflow>,
+    pub(crate) workflows: IndexMap<WorkflowKey, Workflow>,
 }
 
 impl WorkflowRegistry {
@@ -137,9 +138,7 @@ impl WorkflowRegistry {
         self.register(workflow)
     }
 
-    pub(crate) fn iter_workflows(
-        &self,
-    ) -> std::collections::hash_map::Iter<'_, WorkflowKey, Workflow> {
+    pub(crate) fn iter_workflows(&self) -> indexmap::map::Iter<'_, WorkflowKey, Workflow> {
         self.workflows.iter()
     }
 
@@ -171,7 +170,7 @@ impl WorkflowRegistry {
 }
 
 pub(crate) struct AuditRegistry {
-    pub(crate) workflow_audits: HashMap<&'static str, Box<dyn WorkflowAudit>>,
+    pub(crate) workflow_audits: IndexMap<&'static str, Box<dyn WorkflowAudit>>,
 }
 
 impl AuditRegistry {
@@ -193,10 +192,8 @@ impl AuditRegistry {
         self.workflow_audits.insert(ident, audit);
     }
 
-    pub(crate) fn iter_workflow_audits(
-        &mut self,
-    ) -> std::collections::hash_map::IterMut<'_, &str, Box<dyn WorkflowAudit>> {
-        self.workflow_audits.iter_mut()
+    pub(crate) fn iter_workflow_audits(&self) -> indexmap::map::Iter<&str, Box<dyn WorkflowAudit>> {
+        self.workflow_audits.iter()
     }
 }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,19 +1,109 @@
 //! Functionality for registering and managing the lifecycles of
 //! audits.
 
-use std::{collections::HashMap, path::Path, process::ExitCode};
+use std::{collections::HashMap, fmt::Display, process::ExitCode};
 
 use crate::{
     audit::WorkflowAudit,
     config::Config,
     finding::{Confidence, Finding, Persona, Severity},
-    models::Workflow,
+    models::{RepositoryUses, Workflow},
     App,
 };
 use anyhow::{anyhow, Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use serde::Serialize;
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize)]
+pub(crate) struct LocalWorkflowKey {
+    path: Utf8PathBuf,
+}
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize)]
+pub(crate) struct RemoteWorkflowKey {
+    owner: String,
+    repo: String,
+    git_ref: Option<String>,
+    path: Utf8PathBuf,
+}
+
+/// A unique identifying "key" for a workflow file in a given run of zizmor.
+///
+/// zizmor currently knows two different kinds of keys: local keys
+/// are just canonical paths to files on disk, while remote keys are
+/// relative paths within a referenced GitHub repository.
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize)]
+pub(crate) enum WorkflowKey {
+    Local(LocalWorkflowKey),
+    Remote(RemoteWorkflowKey),
+}
+
+impl Display for WorkflowKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WorkflowKey::Local(local) => write!(f, "file://{path}", path = local.path),
+            WorkflowKey::Remote(remote) => {
+                // No ref means assume HEAD, i.e. whatever's on the default branch.
+                let git_ref = remote.git_ref.as_deref().unwrap_or("HEAD");
+                write!(
+                    f,
+                    "https://github.com/{owner}/{repo}/blob/{git_ref}/{path}",
+                    owner = remote.owner,
+                    repo = remote.repo,
+                    path = remote.path
+                )
+            }
+        }
+    }
+}
+
+impl WorkflowKey {
+    pub(crate) fn local(path: Utf8PathBuf) -> Result<Self> {
+        // All workflow keys must have a filename component.
+        if path.file_name().is_none() {
+            return Err(anyhow!("invalid local workflow: no filename component"));
+        }
+
+        Ok(Self::Local(LocalWorkflowKey { path }))
+    }
+
+    pub(crate) fn remote(slug: &RepositoryUses, path: String) -> Result<Self> {
+        if Utf8Path::new(&path).file_name().is_none() {
+            return Err(anyhow!("invalid remote workflow: no filename component"));
+        }
+
+        Ok(Self::Remote(RemoteWorkflowKey {
+            owner: slug.owner.into(),
+            repo: slug.repo.into(),
+            git_ref: slug.git_ref.map(Into::into),
+            path: path.into(),
+        }))
+    }
+
+    /// Returns this [`WorkflowKey`]'s filepath component.
+    ///
+    /// This will be an absolute path for local keys, and a relative
+    /// path for remote keys.
+    pub(crate) fn path(&self) -> &str {
+        match self {
+            WorkflowKey::Local(local) => local.path.as_str(),
+            WorkflowKey::Remote(remote) => remote.path.as_str(),
+        }
+    }
+
+    /// Returns the filename component of this [`WorkflowKey`].
+    pub(crate) fn filename(&self) -> &str {
+        // NOTE: Safe unwraps, since the presence of a filename component
+        // is a construction invariant of all `WorkflowKey` variants.
+        match self {
+            WorkflowKey::Local(local) => local.path.file_name().unwrap(),
+            WorkflowKey::Remote(remote) => remote.path.file_name().unwrap(),
+        }
+    }
+}
 
 pub(crate) struct WorkflowRegistry {
-    pub(crate) workflows: HashMap<String, Workflow>,
+    pub(crate) workflows: HashMap<WorkflowKey, Workflow>,
 }
 
 impl WorkflowRegistry {
@@ -28,46 +118,34 @@ impl WorkflowRegistry {
     }
 
     pub(crate) fn register(&mut self, workflow: Workflow) -> Result<()> {
-        let Some((_, name)) = workflow.path.rsplit_once("/") else {
-            return Err(anyhow!("invalid workflow: no filename component"));
-        };
-
-        if self.workflows.contains_key(name) {
-            return Err(anyhow!("can't register {name} more than once"));
+        if self.workflows.contains_key(&workflow.key) {
+            return Err(anyhow!(
+                "can't register {key} more than once",
+                key = workflow.key
+            ));
         }
 
-        self.workflows.insert(name.into(), workflow);
+        self.workflows.insert(workflow.key.clone(), workflow);
 
         Ok(())
     }
 
-    pub(crate) fn register_by_path(&mut self, path: &Path) -> Result<()> {
-        let name = path
-            .file_name()
-            .ok_or_else(|| anyhow!("invalid workflow: no filename component"))?
-            .to_str()
-            .ok_or_else(|| anyhow!("invalid workflow: path is not UTF-8"))?
-            .to_string();
+    pub(crate) fn register_by_path(&mut self, path: &Utf8Path) -> Result<()> {
+        let workflow =
+            Workflow::from_file(path).with_context(|| "couldn't load workflow from file")?;
 
-        if self.workflows.contains_key(&name) {
-            return Err(anyhow!("can't register {name} more than once"));
-        }
-
-        self.workflows.insert(
-            name,
-            Workflow::from_file(path).with_context(|| "couldn't load workflow from file")?,
-        );
-
-        Ok(())
+        self.register(workflow)
     }
 
-    pub(crate) fn iter_workflows(&self) -> std::collections::hash_map::Iter<'_, String, Workflow> {
+    pub(crate) fn iter_workflows(
+        &self,
+    ) -> std::collections::hash_map::Iter<'_, WorkflowKey, Workflow> {
         self.workflows.iter()
     }
 
-    pub(crate) fn get_workflow(&self, name: &str) -> &Workflow {
+    pub(crate) fn get_workflow(&self, key: &WorkflowKey) -> &Workflow {
         self.workflows
-            .get(name)
+            .get(key)
             .expect("API misuse: requested an un-registered workflow")
     }
 
@@ -80,15 +158,14 @@ impl WorkflowRegistry {
     /// The exceptional case here is when zizmor is asked to scan a single
     /// workflow at some arbitrary location on disk. In that case, just
     /// the base workflow filename itself is returned.
-    pub(crate) fn get_workflow_relative_path(&self, name: &str) -> &str {
-        let workflow = self.get_workflow(name);
-        let workflow_path = Path::new(&workflow.path);
+    pub(crate) fn get_workflow_relative_path<'a>(&self, key: &'a WorkflowKey) -> &'a str {
+        let path = key.path();
 
-        match workflow.path.rfind(".github/workflows") {
-            Some(start) => &workflow.path[start..],
+        match path.rfind(".github/workflows") {
+            Some(start) => &path[start..],
             // NOTE: Unwraps are safe since file component is always present and
             // all paths are UTF-8 by construction.
-            None => workflow_path.file_name().unwrap().to_str().unwrap(),
+            None => key.filename(),
         }
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -27,7 +27,21 @@ impl WorkflowRegistry {
         self.workflows.len()
     }
 
-    pub(crate) fn register_workflow(&mut self, path: &Path) -> Result<()> {
+    pub(crate) fn register(&mut self, workflow: Workflow) -> Result<()> {
+        let Some((_, name)) = workflow.path.rsplit_once("/") else {
+            return Err(anyhow!("invalid workflow: no filename component"));
+        };
+
+        if self.workflows.contains_key(name) {
+            return Err(anyhow!("can't register {name} more than once"));
+        }
+
+        self.workflows.insert(name.into(), workflow);
+
+        Ok(())
+    }
+
+    pub(crate) fn register_by_path(&mut self, path: &Path) -> Result<()> {
         let name = path
             .file_name()
             .ok_or_else(|| anyhow!("invalid workflow: no filename component"))?

--- a/src/render.rs
+++ b/src/render.rs
@@ -31,7 +31,7 @@ pub(crate) fn finding_snippet<'w>(
     // by their enclosing workflow to generate each snippet correctly.
     let mut locations_by_workflow: HashMap<&WorkflowKey, Vec<&Location<'w>>> = HashMap::new();
     for location in &finding.locations {
-        match locations_by_workflow.entry(&location.symbolic.key) {
+        match locations_by_workflow.entry(location.symbolic.key) {
             Entry::Occupied(mut e) => {
                 e.get_mut().push(location);
             }
@@ -49,7 +49,7 @@ pub(crate) fn finding_snippet<'w>(
             Snippet::source(workflow.document.source())
                 .fold(true)
                 .line_start(1)
-                .origin(&workflow.link.as_deref().unwrap_or(workflow_key.path()))
+                .origin(workflow.link.as_deref().unwrap_or(workflow_key.path()))
                 .annotations(locations.iter().map(|loc| {
                     let annotation = match loc.symbolic.link {
                         Some(ref link) => link,

--- a/src/render.rs
+++ b/src/render.rs
@@ -4,7 +4,7 @@ use std::collections::{hash_map::Entry, HashMap};
 
 use crate::{
     finding::{Finding, Location, Severity},
-    registry::{FindingRegistry, WorkflowRegistry},
+    registry::{FindingRegistry, WorkflowKey, WorkflowRegistry},
 };
 use annotate_snippets::{Level, Renderer, Snippet};
 use anstream::{print, println};
@@ -29,9 +29,9 @@ pub(crate) fn finding_snippet<'w>(
 ) -> Vec<Snippet<'w>> {
     // Our finding might span multiple workflows, so we need to group locations
     // by their enclosing workflow to generate each snippet correctly.
-    let mut locations_by_workflow: HashMap<&str, Vec<&Location<'w>>> = HashMap::new();
+    let mut locations_by_workflow: HashMap<&WorkflowKey, Vec<&Location<'w>>> = HashMap::new();
     for location in &finding.locations {
-        match locations_by_workflow.entry(location.symbolic.name) {
+        match locations_by_workflow.entry(&location.symbolic.key) {
             Entry::Occupied(mut e) => {
                 e.get_mut().push(location);
             }
@@ -42,14 +42,14 @@ pub(crate) fn finding_snippet<'w>(
     }
 
     let mut snippets = vec![];
-    for (workflow_name, locations) in locations_by_workflow {
-        let workflow = registry.get_workflow(workflow_name);
+    for (workflow_key, locations) in locations_by_workflow {
+        let workflow = registry.get_workflow(workflow_key);
 
         snippets.push(
             Snippet::source(workflow.document.source())
                 .fold(true)
                 .line_start(1)
-                .origin(&workflow.path)
+                .origin(&workflow.link.as_deref().unwrap_or(workflow_key.path()))
                 .annotations(locations.iter().map(|loc| {
                     let annotation = match loc.symbolic.link {
                         Some(ref link) => link,

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -69,7 +69,7 @@ fn build_locations(registry: &WorkflowRegistry, locations: &[Location<'_>]) -> V
                         .artifact_location(
                             ArtifactLocation::builder()
                                 .uri_base_id("%SRCROOT%")
-                                .uri(registry.get_workflow_relative_path(location.symbolic.name))
+                                .uri(registry.get_workflow_relative_path(location.symbolic.key))
                                 .build(),
                         )
                         .region(

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,6 +26,11 @@ impl AuditState {
     /// Return a cache-configured GitHub API client, if
     /// a GitHub API token is present.
     pub(crate) fn github_client(&self) -> Option<Client> {
+        // Respect the user's offline setting above everything else.
+        if self.offline {
+            return None;
+        }
+
         self.gh_token
             .as_ref()
             .map(|token| Client::new(token, self.caches.clone()))

--- a/src/state.rs
+++ b/src/state.rs
@@ -9,7 +9,7 @@ use crate::{
 
 #[derive(Clone)]
 pub(crate) struct AuditState {
-    pub(crate) offline: bool,
+    pub(crate) no_online_audits: bool,
     pub(crate) gh_token: Option<String>,
     pub(crate) caches: Caches,
 }
@@ -18,7 +18,7 @@ impl AuditState {
     pub(crate) fn new(app: &App) -> Self {
         Self {
             caches: Caches::new(),
-            offline: app.offline,
+            no_online_audits: app.no_online_audits,
             gh_token: app.gh_token.clone(),
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -26,11 +26,6 @@ impl AuditState {
     /// Return a cache-configured GitHub API client, if
     /// a GitHub API token is present.
     pub(crate) fn github_client(&self) -> Option<Client> {
-        // Respect the user's offline setting above everything else.
-        if self.offline {
-            return None;
-        }
-
         self.gh_token
             .as_ref()
             .map(|token| Client::new(token, self.caches.clone()))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,23 @@
 
 use github_actions_models::common::expr::ExplicitExpr;
 
+/// Convenience trait for inline transformations of `Self`.
+///
+/// This is similar to the `tap` crate's `Pipe` trait, except that
+/// it's a little less general (`pipe<T>(T) -> T``, instead of
+/// `pipe<T, U>(T) -> U`).
+pub(crate) trait PipeSelf<F> {
+    fn pipe(self, f: F) -> Self
+    where
+        F: FnOnce(Self) -> Self,
+        Self: Sized,
+    {
+        f(self)
+    }
+}
+
+impl<T, F> PipeSelf<F> for T where T: Sized {}
+
 /// Splits the given `patterns` string into one or more patterns, using
 /// approximately the same rules as GitHub's `@actions/glob` package.
 pub(crate) fn split_patterns(patterns: &str) -> impl Iterator<Item = &str> {

--- a/tests/snapshots/snapshot__cant_retrieve.snap
+++ b/tests/snapshots/snapshot__cant_retrieve.snap
@@ -1,0 +1,7 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().output(OutputMode::Stderr).args([\"pypa/sampleproject\"]).run()?"
+snapshot_kind: text
+---
+error: can't retrieve repository: pypa/sampleproject
+ = note: try removing --offline or passing --gh-token <TOKEN>

--- a/tests/snapshots/snapshot__conflicting_online_options-2.snap
+++ b/tests/snapshots/snapshot__conflicting_online_options-2.snap
@@ -1,0 +1,10 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().output(OutputMode::Stderr).offline(true).args([\"--gh-token=phony\"]).run()?"
+snapshot_kind: text
+---
+error: the argument '--gh-token <GH_TOKEN>' cannot be used with '--offline'
+
+Usage: zizmor --gh-token <GH_TOKEN> <INPUTS>...
+
+For more information, try '--help'.

--- a/tests/snapshots/snapshot__conflicting_online_options-3.snap
+++ b/tests/snapshots/snapshot__conflicting_online_options-3.snap
@@ -1,0 +1,10 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().output(OutputMode::Stderr).setenv(\"ZIZMOR_OFFLINE\",\n\"true\").setenv(\"GH_TOKEN\", \"phony\").run()?"
+snapshot_kind: text
+---
+error: the argument '--offline' cannot be used with '--gh-token <GH_TOKEN>'
+
+Usage: zizmor --offline <INPUTS>...
+
+For more information, try '--help'.

--- a/tests/snapshots/snapshot__conflicting_online_options.snap
+++ b/tests/snapshots/snapshot__conflicting_online_options.snap
@@ -1,0 +1,10 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().output(OutputMode::Stderr).setenv(\"GH_TOKEN\",\n\"phony\").offline(true).run()?"
+snapshot_kind: text
+---
+error: the argument '--offline' cannot be used with '--gh-token <GH_TOKEN>'
+
+Usage: zizmor --offline <INPUTS>...
+
+For more information, try '--help'.


### PR DESCRIPTION
~~WIP.~~

Once finished, this will enable `zizmor foo/bar`, where `foo/bar` is a GitHub repo that `zizmor` will extract workflows to audit from.

~~(The `@`-prefix is not a firm design choice -- I might remove that.)~~

Closes #50

Closes #177

CC @miketheman as an interested party :slightly_smiling_face: 