### PR TITLE
docs: restore search plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - "crates.io 🔗": https://crates.io/crates/zizmor
 
 plugins:
+  - search
   - social
 
 theme:


### PR DESCRIPTION
In f41f6925007350030316 a plugin list was added to the mkdocs config to add the "social" plugin. This removed the default "search" plugin (I assume by accident).

See https://www.mkdocs.org/user-guide/configuration/#plugins for the default plugins.

The plugin is quite handy for searching audit rules, etc., so fix it by adding "search" back to the enabled plugins.