### PR TITLE
feat: remove --no-progress

### DIFF
--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -20,8 +20,6 @@ Options:
           Increase logging verbosity
   -q, --quiet...
           Decrease logging verbosity
-  -n, --no-progress
-          Disable the progress bar. This is useful primarily when running with a high verbosity level, as the two will fight for stderr
       --format <FORMAT>
           The output format to emit. By default, plain text will be emitted [default: plain] [possible values: plain, json, sarif]
   -c, --config <CONFIG>

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,11 +66,6 @@ struct App {
     #[command(flatten)]
     verbose: clap_verbosity_flag::Verbosity<InfoLevel>,
 
-    /// Disable the progress bar. This is useful primarily when running
-    /// with a high verbosity level, as the two will fight for stderr.
-    #[arg(short, long)]
-    no_progress: bool,
-
     /// The output format to emit. By default, plain text will be emitted
     #[arg(long, value_enum, default_value_t)]
     format: OutputFormat,


### PR DESCRIPTION
This is now obsolete, thanks to the tracing/
progress tracking unification. Most users who
were using this probably want `-q` instead.

BREAKING CHANGE: removes the `--no-progress` flag