### PR TITLE
fix: template-injection: ignore another safe context

### DIFF
--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -41,7 +41,8 @@ const SAFE_CONTEXTS: &[&str] = &[
     "github.event.issue.number",
     "github.event.merge_group.base_sha",
     "github.event.number",
-    "github.event.pull_request.number",
+    "github.event.pull_request.commits", // number of commits in PR
+    "github.event.pull_request.number",  // the PR's own number
     "github.event.workflow_run.id",
     // Information about the GitHub repository
     "github.repository",


### PR DESCRIPTION
See https://github.com/python/cpython/pull/127749#discussion_r1875069336 -- this took a bit of sleuthing, but the `pull_request` event body's `commits` field can only ever contain a number, meaning that it isn't itself a source of code injection.

Ref: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request