### PR TITLE
chore: Makefile: avoid a venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,14 @@
-VENV = .venv
-VENV_BIN := $(VENV)/bin
-
 .PHONY: all
 all:
 	@echo "Run my targets individually!"
 
 .PHONY: site
-site: $(VENV)
-	$(VENV_BIN)/mkdocs build
+site: site-requirements.txt
+	uvx --with-requirements $< mkdocs build
 
 .PHONY: site-live
-site-live: $(VENV)
-	$(VENV_BIN)/mkdocs serve
-
-$(VENV): site-requirements.txt
-	uv venv
-	uv pip install -r site-requirements.txt
+site-live: site-requirements.txt
+	uvx --with-requirements $< mkdocs serve
 
 .PHONY: snippets
 snippets:


### PR DESCRIPTION
Use `uvx --with-requirements` directly, since it's just as fast (if not faster).

See #256.