### PR TITLE
fix: bump annotate-snippets to fix crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,12 +38,12 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e35ed54e5ea7997c14ed4c70ba043478db1112e98263b3b035907aa197d991"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
 dependencies = [
  "anstyle",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["command-line-utilities"]
 rust-version = "1.80.1"
 
 [dependencies]
-annotate-snippets = "0.11.4"
+annotate-snippets = "0.11.5"
 anstream = "0.6.18"
 anyhow = "1.0.94"
 camino = { version = "1.1.9", features = ["serde1"] }

--- a/tests/snapshots/snapshot__insecure_commands-2.snap
+++ b/tests/snapshots/snapshot__insecure_commands-2.snap
@@ -6,8 +6,7 @@ snapshot_kind: text
 error[insecure-commands]: execution of insecure workflow commands is enabled
  --> @@INPUT@@:8:5
   |
-8 |       env:
-  |  _____^
+8 | /     env:
 9 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
   | |__________________________________________^ insecure commands enabled here
   |

--- a/tests/snapshots/snapshot__insecure_commands.snap
+++ b/tests/snapshots/snapshot__insecure_commands.snap
@@ -6,8 +6,7 @@ snapshot_kind: text
 error[insecure-commands]: execution of insecure workflow commands is enabled
  --> @@INPUT@@:8:5
   |
-8 |       env:
-  |  _____^
+8 | /     env:
 9 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
   | |__________________________________________^ insecure commands enabled here
   |


### PR DESCRIPTION
This bumps to the latest patch version, which
is noted to fix a panic in string slicing.

Fixes https://github.com/woodruffw/zizmor/issues/263

See: https://github.com/rust-lang/annotate-snippets-rs/issues/161