### PR TITLE
fix: download both .yml and .yaml from repos

### DIFF
--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -238,7 +238,10 @@ impl Client {
             .json()?;
 
         let mut workflows = vec![];
-        for file in resp.into_iter().filter(|file| file.name.ends_with(".yml")) {
+        for file in resp
+            .into_iter()
+            .filter(|file| file.name.ends_with(".yml") || file.name.ends_with(".yaml"))
+        {
             let file_url = format!("{url}/{file}", file = file.name);
             tracing::debug!("fetching {file_url}");
 


### PR DESCRIPTION
Fixes a small bug where we'd only download `foo.yml` and not `foo.yaml` when remote-auditing.