### PR TITLE
fix: move artipacked pendantic finding to auditor

### DIFF
--- a/src/audit/artipacked.rs
+++ b/src/audit/artipacked.rs
@@ -73,8 +73,8 @@ impl WorkflowAudit for Artipacked {
                         Some(EnvValue::Boolean(false)) => continue,
                         Some(EnvValue::Boolean(true)) => {
                             // If a user explicitly sets `persist-credentials: true`,
-                            // they probably mean it. Only report if being pedantic.
-                            vulnerable_checkouts.push((step, Persona::Pedantic))
+                            // they probably mean it. Only report if in auditor mode.
+                            vulnerable_checkouts.push((step, Persona::Auditor))
                         }
                         // TODO: handle expressions and literal strings here.
                         // persist-credentials is true by default.

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -138,6 +138,11 @@ fn artipacked() -> Result<()> {
         .workflow(workflow_under_test("artipacked.yml"))
         .run()?);
 
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("artipacked.yml"))
+        .args(["--persona=auditor"])
+        .run()?);
+
     Ok(())
 }
 

--- a/tests/snapshots/snapshot__artipacked-3.snap
+++ b/tests/snapshots/snapshot__artipacked-3.snap
@@ -1,0 +1,25 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"artipacked.yml\")).args([\"--persona=auditor\"]).run()?"
+snapshot_kind: text
+---
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:13:9
+   |
+13 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+   |         ---------------------------------------------------------------------------- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+
+warning[artipacked]: credential persistence through GitHub Actions artifacts
+  --> @@INPUT@@:18:9
+   |
+18 |         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+   |  _________-
+19 | |         with:
+20 | |           persist-credentials: true
+   | |____________________________________- does not set persist-credentials: false
+   |
+   = note: audit confidence → Low
+
+2 findings: 0 unknown, 0 informational, 0 low, 2 medium, 0 high

--- a/tests/snapshots/snapshot__artipacked.snap
+++ b/tests/snapshots/snapshot__artipacked.snap
@@ -11,15 +11,4 @@ warning[artipacked]: credential persistence through GitHub Actions artifacts
    |
    = note: audit confidence → Low
 
-warning[artipacked]: credential persistence through GitHub Actions artifacts
-  --> @@INPUT@@:18:9
-   |
-18 |         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
-   |  _________-
-19 | |         with:
-20 | |           persist-credentials: true
-   | |____________________________________- does not set persist-credentials: false
-   |
-   = note: audit confidence → Low
-
-2 findings: 0 unknown, 0 informational, 0 low, 2 medium, 0 high
+2 findings (1 suppressed): 0 unknown, 0 informational, 0 low, 1 medium, 0 high


### PR DESCRIPTION
Categorizing this as "pedantic" was incorrect,
since we're raising a finding for something the
user explicitly opted into, and that's what the
auditor persona is for.