### PR TITLE
feat: evaluates a matrix expansion only once

### DIFF
--- a/src/audit/self_hosted_runner.rs
+++ b/src/audit/self_hosted_runner.rs
@@ -109,7 +109,7 @@ impl WorkflowAudit for SelfHostedRunner {
                 LoE::Expr(exp) => {
                     let matrix = Matrix::try_from(&job)?;
 
-                    let expansions = matrix.expand_values();
+                    let expansions = matrix.expanded_values;
 
                     let self_hosted = expansions.iter().any(|(path, expansion)| {
                         exp.as_bare() == path && expansion.contains("self-hosted")


### PR DESCRIPTION
A follow-up from https://github.com/woodruffw/zizmor/pull/231

Just realised that we can expand the Matrix when instantiating, hence storing the expanded values as a field and avoiding a new expansion every time we need to evaluate the same matrix . 😄
