### PR TITLE
fix: template-injection: consider runner.tool_cache safe

### DIFF
--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -70,6 +70,8 @@ const SAFE_CONTEXTS: &[&str] = &[
     "runner.os",
     // GitHub Actions temporary directory, value controlled by the runner itself.
     "runner.temp",
+    // GitHub Actions cached tool directory, value controlled by the runner itself.
+    "runner.tool_cache",
 ];
 
 impl TemplateInjection {


### PR DESCRIPTION
Adds another always-safe context to the safe list.