### PR TITLE
fix: template-injection: more safe contexts

### DIFF
--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -39,6 +39,8 @@ const SAFE_CONTEXTS: &[&str] = &[
     // The GitHub event name (i.e. trigger) is itself safe.
     "github.event_name",
     // Safe keys within the otherwise generally unsafe github.event context.
+    "github.event.after",  // hexadecimal SHA ref
+    "github.event.before", // hexadecimal SHA ref
     "github.event.issue.number",
     "github.event.merge_group.base_sha",
     "github.event.number",


### PR DESCRIPTION
`github.event.before` and `github.event.after` are always SHA references, when present.

`github.event.before` is documented but `github.event.after` is seemingly not -- I found independent corroboration here: <https://www.kenmuse.com/blog/the-many-shas-of-a-github-pull-request/>

See https://github.com/curl/curl/pull/15746.