### PR TITLE
ci: disable wheel builds on pull_request

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -6,7 +6,6 @@ on:
       - main
     tags:
       - '*'
-  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Having this matrix run on every PR badly messes with GHA's base ratelimits, since it does an incredible amount of cache reads/writes. 