### PR TITLE
fix: expands_to_static_values considers expressions inside strings

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -280,7 +280,7 @@ impl<'w> Matrix<'w> {
             // one or more expressions (e.g. `foo-${{ bar }}-${{ baz }}`). So we
             // need to check for *any* expression in the expanded value,
             // not just that it starts and ends with the expression delimiters.
-            let expansion_contains_expression = !extract_expressions(&expansion).is_empty();
+            let expansion_contains_expression = !extract_expressions(expansion).is_empty();
             context == path && expansion_contains_expression
         });
 

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -251,5 +251,9 @@ fn template_injection() -> Result<()> {
         .workflow(workflow_under_test("template-injection/issue-22-repro.yml"))
         .run()?);
 
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("template-injection/pr-317-repro.yml"))
+        .run()?);
+
     Ok(())
 }

--- a/tests/snapshots/snapshot__template_injection-4.snap
+++ b/tests/snapshots/snapshot__template_injection-4.snap
@@ -1,0 +1,19 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"template-injection/pr-317-repro.yml\")).run()?"
+snapshot_kind: text
+---
+warning[template-injection]: code injection via template expansion
+  --> @@INPUT@@:25:9
+   |
+25 |         - run: |
+   |  _________-
+26 | |           echo ${{ matrix.bar }}
+   | |                                 -
+   | |_________________________________|
+   |                                   this step
+   |                                   matrix.bar may expand into attacker-controllable code
+   |
+   = note: audit confidence → Medium
+
+1 finding: 0 unknown, 0 informational, 0 low, 1 medium, 0 high

--- a/tests/test-data/template-injection/pr-317-repro.yml
+++ b/tests/test-data/template-injection/pr-317-repro.yml
@@ -1,0 +1,26 @@
+# reproduction case for https://github.com/woodruffw/zizmor/pull/317
+
+name: PR-317-REPRO
+on:
+  pull_request:
+
+jobs:
+  PR-317-REPRO:
+    name: PR-317-REPRO
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - foo: 123
+            bar: abc
+
+          - foo: 456
+            # BUG: this should be detected as a matrix expansion
+            # candidate containing an expression, but was not
+            # before #317.
+            bar: prefix-${{ github.repository_owner }}
+
+    steps:
+      - run: |
+          echo ${{ matrix.bar }}


### PR DESCRIPTION
This tweaks #298 slightly, following the regression noted in https://github.com/woodruffw/zizmor/issues/22#issuecomment-2543128489 -- the previous `expands_to_static_values` only checked whether the expanded matrix value was *precisely* an expression, but we also need to handle the case where an expanded matrix value *contains* an expression.

By way of example:

```yaml
matrix:
  include:
    - foo: 123
      bar: ${{ expression }} # correctly fails expands_to_static_values
    - foo: 456
      bar: prefix-${{ expression }} # incorrectly passes expands_to_static_values
```

I'll work on a testcase for this as well. CC @ubiratansoares for viz 🙂 