### PR TITLE
feat: add 'primary' locations

### DIFF
--- a/src/audit/artipacked.rs
+++ b/src/audit/artipacked.rs
@@ -105,6 +105,7 @@ impl WorkflowAudit for Artipacked {
                             .add_location(
                                 checkout
                                     .location()
+                                    .primary()
                                     .annotated("does not set persist-credentials: false"),
                             )
                             .build(workflow)?,
@@ -127,6 +128,7 @@ impl WorkflowAudit for Artipacked {
                                 .add_location(
                                     checkout
                                         .location()
+                                        .primary()
                                         .annotated("does not set persist-credentials: false"),
                                 )
                                 .add_location(

--- a/src/audit/dangerous_triggers.rs
+++ b/src/audit/dangerous_triggers.rs
@@ -28,6 +28,7 @@ impl WorkflowAudit for DangerousTriggers {
                     .add_location(
                         workflow
                             .location()
+                            .primary()
                             .with_keys(&["on".into()])
                             .annotated("pull_request_target is almost always used insecurely"),
                     )
@@ -42,6 +43,7 @@ impl WorkflowAudit for DangerousTriggers {
                     .add_location(
                         workflow
                             .location()
+                            .primary()
                             .with_keys(&["on".into()])
                             .annotated("workflow_run is almost always used insecurely"),
                     )

--- a/src/audit/excessive_permissions.rs
+++ b/src/audit/excessive_permissions.rs
@@ -65,6 +65,7 @@ impl WorkflowAudit for ExcessivePermissions {
                     .add_location(
                         workflow
                             .location()
+                            .primary()
                             .with_keys(&["permissions".into()])
                             .annotated(note),
                     )
@@ -86,6 +87,7 @@ impl WorkflowAudit for ExcessivePermissions {
                         .confidence(confidence)
                         .add_location(
                             job.location()
+                                .primary()
                                 .with_keys(&["permissions".into()])
                                 .annotated(note),
                         )

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -183,6 +183,7 @@ impl WorkflowAudit for GitHubEnv {
                         .confidence(Confidence::Low)
                         .add_location(
                             step.location()
+                                .primary()
                                 .with_keys(&["run".into()])
                                 .annotated("GITHUB_ENV write may allow code execution"),
                         )

--- a/src/audit/hardcoded_container_credentials.rs
+++ b/src/audit/hardcoded_container_credentials.rs
@@ -59,6 +59,7 @@ impl WorkflowAudit for HardcodedContainerCredentials {
                             .confidence(Confidence::High)
                             .add_location(
                                 job.location()
+                                    .primary()
                                     .with_keys(&["container".into(), "credentials".into()])
                                     .annotated("container registry password is hard-coded"),
                             )
@@ -85,6 +86,7 @@ impl WorkflowAudit for HardcodedContainerCredentials {
                                 .confidence(Confidence::High)
                                 .add_location(
                                     job.location()
+                                        .primary()
                                         .with_keys(&[
                                             "services".into(),
                                             service.as_str().into(),

--- a/src/audit/impostor_commit.rs
+++ b/src/audit/impostor_commit.rs
@@ -141,7 +141,9 @@ impl WorkflowAudit for ImpostorCommit {
                                 Self::finding()
                                     .severity(Severity::High)
                                     .confidence(Confidence::High)
-                                    .add_location(step.location().annotated(IMPOSTOR_ANNOTATION))
+                                    .add_location(
+                                        step.location().primary().annotated(IMPOSTOR_ANNOTATION),
+                                    )
                                     .build(workflow)?,
                             );
                         }
@@ -159,7 +161,9 @@ impl WorkflowAudit for ImpostorCommit {
                             Self::finding()
                                 .severity(Severity::High)
                                 .confidence(Confidence::High)
-                                .add_location(job.location().annotated(IMPOSTOR_ANNOTATION))
+                                .add_location(
+                                    job.location().primary().annotated(IMPOSTOR_ANNOTATION),
+                                )
                                 .build(workflow)?,
                         );
                     }

--- a/src/audit/insecure_commands.rs
+++ b/src/audit/insecure_commands.rs
@@ -30,7 +30,7 @@ impl InsecureCommands {
             .severity(Severity::High)
             .persona(Persona::Auditor)
             .add_location(
-                location.with_keys(&["env".into()]).annotated(
+                location.primary().with_keys(&["env".into()]).annotated(
                     "non-static environment may contain ACTIONS_ALLOW_UNSECURE_COMMANDS",
                 ),
             )
@@ -47,6 +47,7 @@ impl InsecureCommands {
             .severity(Severity::High)
             .add_location(
                 location
+                    .primary()
                     .with_keys(&["env".into()])
                     .annotated("insecure commands enabled here"),
             )

--- a/src/audit/known_vulnerable_actions.rs
+++ b/src/audit/known_vulnerable_actions.rs
@@ -150,6 +150,7 @@ impl WorkflowAudit for KnownVulnerableActions {
                     .severity(severity)
                     .add_location(
                         step.location()
+                            .primary()
                             .with_keys(&["uses".into()])
                             .annotated(&id)
                             .with_url(format!("https://github.com/advisories/{id}")),

--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -84,6 +84,7 @@ impl WorkflowAudit for RefConfusion {
                                     .confidence(Confidence::High)
                                     .add_location(
                                         step.location()
+                                            .primary()
                                             .with_keys(&["uses".into()])
                                             .annotated(REF_CONFUSION_ANNOTATION),
                                     )
@@ -102,7 +103,9 @@ impl WorkflowAudit for RefConfusion {
                             Self::finding()
                                 .severity(Severity::Medium)
                                 .confidence(Confidence::High)
-                                .add_location(job.location().annotated(REF_CONFUSION_ANNOTATION))
+                                .add_location(
+                                    job.location().primary().annotated(REF_CONFUSION_ANNOTATION),
+                                )
                                 .build(workflow)?,
                         )
                     }

--- a/src/audit/self_hosted_runner.rs
+++ b/src/audit/self_hosted_runner.rs
@@ -62,6 +62,7 @@ impl WorkflowAudit for SelfHostedRunner {
                                     .persona(Persona::Auditor)
                                     .add_location(
                                         job.location()
+                                            .primary()
                                             .with_keys(&["runs-on".into()])
                                             .annotated("self-hosted runner used here"),
                                     )
@@ -78,9 +79,12 @@ impl WorkflowAudit for SelfHostedRunner {
                                     .severity(Severity::Unknown)
                                     .persona(Persona::Auditor)
                                     .add_location(
-                                        job.location().with_keys(&["runs-on".into()]).annotated(
-                                            "expression may expand into a self-hosted runner",
-                                        ),
+                                        job.location()
+                                            .primary()
+                                            .with_keys(&["runs-on".into()])
+                                            .annotated(
+                                                "expression may expand into a self-hosted runner",
+                                            ),
                                     )
                                     .build(workflow)?,
                             );
@@ -99,6 +103,7 @@ impl WorkflowAudit for SelfHostedRunner {
                         .persona(Persona::Auditor)
                         .add_location(
                             job.location()
+                                .primary()
                                 .with_keys(&["runs-on".into()])
                                 .annotated("runner group implies self-hosted runner"),
                         )
@@ -129,9 +134,12 @@ impl WorkflowAudit for SelfHostedRunner {
                                         .annotated("matrix declares self-hosted runner"),
                                 )
                                 .add_location(
-                                    job.location().with_keys(&["runs-on".into()]).annotated(
-                                        "expression may expand into a self-hosted runner",
-                                    ),
+                                    job.location()
+                                        .primary()
+                                        .with_keys(&["runs-on".into()])
+                                        .annotated(
+                                            "expression may expand into a self-hosted runner",
+                                        ),
                                 )
                                 .build(workflow)?,
                         )

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -266,7 +266,7 @@ impl WorkflowAudit for TemplateInjection {
                     .persona(persona)
                     .add_location(step.location_with_name())
                     .add_location(
-                        script_loc.clone().annotated(format!(
+                        script_loc.clone().primary().annotated(format!(
                             "{expr} may expand into attacker-controllable code"
                         )),
                     )

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -44,6 +44,7 @@ impl WorkflowAudit for UnpinnedUses {
                 .persona(persona)
                 .add_location(
                     step.location()
+                        .primary()
                         .with_keys(&["uses".into()])
                         .annotated(annotation),
                 )

--- a/src/audit/use_trusted_publishing.rs
+++ b/src/audit/use_trusted_publishing.rs
@@ -87,6 +87,7 @@ impl WorkflowAudit for UseTrustedPublishing {
             .confidence(Confidence::High)
             .add_location(
                 step.location()
+                    .primary()
                     .with_keys(&["uses".into()])
                     .annotated("this step"),
             );
@@ -98,6 +99,7 @@ impl WorkflowAudit for UseTrustedPublishing {
                 candidate
                     .add_location(
                         step.location()
+                            .primary()
                             .with_keys(&["with".into(), "password".into()])
                             .annotated(USES_MANUAL_CREDENTIAL),
                     )
@@ -110,7 +112,7 @@ impl WorkflowAudit for UseTrustedPublishing {
         {
             findings.push(
                 candidate
-                    .add_location(step.location().annotated(USES_MANUAL_CREDENTIAL))
+                    .add_location(step.location().primary().annotated(USES_MANUAL_CREDENTIAL))
                     .build(step.workflow())?,
             );
         }

--- a/src/models.rs
+++ b/src/models.rs
@@ -95,6 +95,7 @@ impl Workflow {
             annotation: "this workflow".to_string(),
             link: None,
             route: Route::new(),
+            primary: false,
         }
     }
 


### PR DESCRIPTION
This was pointed out by @fcasal: the current model assumes that all locations are equal, while SARIF distinguishes between "primary" locations (i.e. those in `locations`) and "secondary" locations (i.e. those in `relatedLocations`). This is especially relevant for SARIF presentation tools like GH itself, which assume that `locations` only contains a single member.

This tweaks our models and updates all audits to emit a "primary" location for the most salient part of each finding. The salient part of each finding is subjective.

This should improve the presentation quality for our SARIF outputs. One downside to this approach is that every audit needs to explicitly annotate a primary location.

Fixes #66.