### PR TITLE
feat: Fix Sarif schema and add rules to Sarif files 

### DIFF
--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -40,7 +40,7 @@ impl From<Severity> for ResultLevel {
 pub(crate) fn build(registry: &WorkflowRegistry, findings: &[Finding]) -> Sarif {
     Sarif::builder()
         .version("2.1.0")
-        .schema("https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-external-property-file-schema-2.1.0.json")
+        .schema("https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json")
         .runs([build_run(registry, findings)])
         .build()
 }

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -70,7 +70,7 @@ fn build_results(registry: &WorkflowRegistry, findings: &[Finding]) -> Vec<Sarif
 
 fn build_result(registry: &WorkflowRegistry, finding: &Finding<'_>) -> SarifResult {
     SarifResult::builder()
-        .message(finding.ident)
+        .message(finding.desc)
         .rule_id(finding.ident)
         .locations(build_locations(
             registry,


### PR DESCRIPTION
This PR

- fixes the schema used in the sarif files
- adds a rules section with the documentation URL 
- replaces the finding identifier with the finding description in the result's message 

When viewed with the Sarif Explorer VSCode extension,
Before
<img width="798" alt="image" src="https://github.com/user-attachments/assets/de66e039-73e4-4b61-bd67-142867268b37" />

After 
<img width="798" alt="image" src="https://github.com/user-attachments/assets/14bdadbc-f55e-428e-986b-5bd7ff2fcc3a" />
