### PR TITLE
fix: excessive-permissions: be less noisy on one-job workflows

### DIFF
--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -316,3 +316,21 @@ fn cache_poisoning() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn excessive_permissions() -> Result<()> {
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/issue-336-repro.yml"
+        ))
+        .run()?);
+
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/issue-336-repro.yml"
+        ))
+        .args(["--pedantic"])
+        .run()?);
+
+    Ok(())
+}

--- a/tests/snapshots/snapshot__excessive_permissions-2.snap
+++ b/tests/snapshots/snapshot__excessive_permissions-2.snap
@@ -1,0 +1,15 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"excessive-permissions/issue-336-repro.yml\")).args([\"--pedantic\"]).run()?"
+snapshot_kind: text
+---
+error[excessive-permissions]: overly broad workflow or job-level permissions
+ --> @@INPUT@@:3:1
+  |
+3 | / permissions:
+4 | |   contents: write
+  | |_________________^ contents: write is overly broad at the workflow level
+  |
+  = note: audit confidence → High
+
+1 finding: 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/tests/snapshots/snapshot__excessive_permissions.snap
+++ b/tests/snapshots/snapshot__excessive_permissions.snap
@@ -1,0 +1,6 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"excessive-permissions/issue-336-repro.yml\")).run()?"
+snapshot_kind: text
+---
+No findings to report. Good job! (1 suppressed)

--- a/tests/test-data/excessive-permissions/issue-336-repro.yml
+++ b/tests/test-data/excessive-permissions/issue-336-repro.yml
@@ -1,0 +1,12 @@
+on: push
+
+permissions:
+  contents: write
+
+jobs:
+  single:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false


### PR DESCRIPTION
This should reduce the amount of noise in single-job workflows, per #336.

CC @pietroalbini

Signed-off-by: William Woodruff <william@yossarian.net>

Fixes #336.