### PR TITLE
fix: handle context accesses following calls

### DIFF
--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -94,9 +94,6 @@ impl TemplateInjection {
             // indexing expressions unsafe and `Expr::Star` only occurs
             // within indices at the moment.
             Expr::Star => unreachable!(),
-            // NOTE: Some index operations may be safe, but for now
-            // we consider them all unsafe.
-            Expr::Index { .. } => false,
             // NOTE: Some function calls may be safe, but for now
             // we consider them all unsafe.
             Expr::Call { .. } => false,

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -90,16 +90,15 @@ impl TemplateInjection {
             Expr::String(_) => true,
             Expr::Boolean(_) => true,
             Expr::Null => true,
-            // NOTE: Currently unreachable, since we churlishly consider
-            // indexing expressions unsafe and `Expr::Star` only occurs
-            // within indices at the moment.
-            Expr::Star => unreachable!(),
+            // NOTE: Currently unreachable, since these only occur
+            // within Expr::Context and we handle that at the top-level.
+            Expr::Star | Expr::Identifier(_) | Expr::Index(_) => unreachable!(),
             // NOTE: Some function calls may be safe, but for now
             // we consider them all unsafe.
             Expr::Call { .. } => false,
             // We consider all context accesses unsafe. This isn't true,
             // but our audit filters the safe ones later on.
-            Expr::Context(_) => false,
+            Expr::Context { .. } => false,
             Expr::BinOp { lhs, op, rhs } => {
                 match op {
                     // `==` and `!=` are always safe, since they evaluate to

--- a/src/expr/expr.pest
+++ b/src/expr/expr.pest
@@ -46,8 +46,8 @@ primary_expr = {
   | string
   | boolean
   | null
-  | function_call
   | context
+  | function_call
   | "(" ~ primary_expr ~ ")"
 }
 
@@ -71,10 +71,10 @@ boolean = { "true" | "false" }
 null = { "null" }
 
 /// Context references (e.g., github.event.issue.number)
-context    = ${ identifier ~ (("." ~ (identifier | star)) | index)* }
+context    = ${ (function_call | identifier) ~ (("." ~ (identifier | star)) | index)* }
 star       =  { "*" }
 identifier = @{ (ASCII_ALPHA | "_" | "-") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
 index      =  { ("[" ~ (or_expr | star) ~ "]") }
 
 /// Function calls
-function_call = { identifier ~ "(" ~ (or_expr ~ ("," ~ or_expr)*)? ~ ")" }
+function_call = !{ identifier ~ "(" ~ (or_expr ~ ("," ~ or_expr)*)? ~ ")" }

--- a/src/expr/expr.pest
+++ b/src/expr/expr.pest
@@ -46,8 +46,8 @@ primary_expr = {
   | string
   | boolean
   | null
-  | function_call
   | index
+  | function_call
   | context
   | "(" ~ primary_expr ~ ")"
 }
@@ -72,12 +72,12 @@ boolean = { "true" | "false" }
 null = { "null" }
 
 /// Context references (e.g., github.event.issue.number)
-context    = ${ identifier ~ (("." ~ (identifier | star)) | index)* }
+context    = ${ identifier ~ ("." ~ (identifier | star))* }
 star       =  { "*" }
 identifier = @{ (ASCII_ALPHA | "_" | "-") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
 
 /// Function calls
-function_call = { identifier ~ "(" ~ (or_expr ~ ("," ~ or_expr)*)? ~ ")" ~ (index | ("." ~ context))? }
+function_call = { identifier ~ "(" ~ (or_expr ~ ("," ~ or_expr)*)? ~ ")" }
 
 /// Index operations
-index = { ("[" ~ (or_expr | star) ~ "]")+ }
+index = { (context | function_call | ("(" ~ primary_expr ~ ")")) ~ ("[" ~ (or_expr | star) ~ "]")+ }

--- a/src/expr/expr.pest
+++ b/src/expr/expr.pest
@@ -47,7 +47,6 @@ primary_expr = {
   | boolean
   | null
   | context
-  | function_call
   | "(" ~ primary_expr ~ ")"
 }
 

--- a/src/expr/expr.pest
+++ b/src/expr/expr.pest
@@ -46,7 +46,6 @@ primary_expr = {
   | string
   | boolean
   | null
-  | index
   | function_call
   | context
   | "(" ~ primary_expr ~ ")"
@@ -72,12 +71,10 @@ boolean = { "true" | "false" }
 null = { "null" }
 
 /// Context references (e.g., github.event.issue.number)
-context    = ${ identifier ~ ("." ~ (identifier | star))* }
+context    = ${ identifier ~ (("." ~ (identifier | star)) | index)* }
 star       =  { "*" }
 identifier = @{ (ASCII_ALPHA | "_" | "-") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
+index      =  { ("[" ~ (or_expr | star) ~ "]") }
 
 /// Function calls
 function_call = { identifier ~ "(" ~ (or_expr ~ ("," ~ or_expr)*)? ~ ")" }
-
-/// Index operations
-index = { (context | function_call | ("(" ~ primary_expr ~ ")")) ~ ("[" ~ (or_expr | star) ~ "]")+ }

--- a/src/expr/expr.pest
+++ b/src/expr/expr.pest
@@ -46,8 +46,8 @@ primary_expr = {
   | string
   | boolean
   | null
-  | index
   | function_call
+  | index
   | context
   | "(" ~ primary_expr ~ ")"
 }
@@ -72,12 +72,12 @@ boolean = { "true" | "false" }
 null = { "null" }
 
 /// Context references (e.g., github.event.issue.number)
-context    = ${ identifier ~ ("." ~ (identifier | star))* }
+context    = ${ identifier ~ (("." ~ (identifier | star)) | index)* }
 star       =  { "*" }
 identifier = @{ (ASCII_ALPHA | "_" | "-") ~ (ASCII_ALPHANUMERIC | "_" | "-")* }
 
 /// Function calls
-function_call = { identifier ~ "(" ~ (or_expr ~ ("," ~ or_expr)*)? ~ ")" }
+function_call = { identifier ~ "(" ~ (or_expr ~ ("," ~ or_expr)*)? ~ ")" ~ (index | ("." ~ context))? }
 
 /// Index operations
-index = { (context | function_call | ("(" ~ primary_expr ~ ")")) ~ ("[" ~ (or_expr | star) ~ "]")+ }
+index = { ("[" ~ (or_expr | star) ~ "]")+ }

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -38,13 +38,13 @@ pub(crate) enum Expr {
     Boolean(bool),
     /// The `null` literal.
     Null,
-    /// The `*` literal within an index.
+    /// The `*` literal within an index or context.
     Star,
     /// A function call.
     Call { func: String, args: Vec<Expr> },
     /// A context identifier component, e.g. `github` in `github.actor`.
     Identifier(String),
-    /// A context index component, e.g. `[0]` in `foo[0]`
+    /// A context index component, e.g. `[0]` in `foo[0]`.
     Index(Box<Expr>),
     /// A full context reference.
     Context { raw: String, components: Vec<Expr> },

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -365,7 +365,6 @@ mod tests {
             "(true == false) == true",
             "(true == (false || true && (true || false))) == true",
             "(github.actor != 'github-actions[bot]' && github.actor) == 'BrewTestBot'",
-            "fromJson(steps.runs.outputs.data).workflow_runs[0].id",
         ];
 
         for case in cases {
@@ -414,19 +413,17 @@ mod tests {
             ("foo.bar.baz", Expr::Context("foo.bar.baz".into())),
             (
                 "foo.bar.baz[1][2]",
-                Expr::Context("foo.bar.baz[1][2]".into()),
-                // Expr::Index {
-                //     parent: Expr::Context("foo.bar.baz".into()).into(),
-                //     indices: vec![Expr::Number(1.0), Expr::Number(2.0)],
-                // },
+                Expr::Index {
+                    parent: Expr::Context("foo.bar.baz".into()).into(),
+                    indices: vec![Expr::Number(1.0), Expr::Number(2.0)],
+                },
             ),
             (
                 "foo.bar.baz[*]",
-                Expr::Context("foo.bar.baz[*]".into()),
-                // Expr::Index {
-                //     parent: Expr::Context("foo.bar.baz".into()).into(),
-                //     indices: vec![Expr::Star],
-                // },
+                Expr::Index {
+                    parent: Expr::Context("foo.bar.baz".into()).into(),
+                    indices: vec![Expr::Star],
+                },
             ),
             (
                 "vegetables.*.ediblePortions",
@@ -476,18 +473,7 @@ mod tests {
                     op: BinOp::Or, rhs: Expr::Boolean(false).into()
                     }.into()
                 }
-            ),
-            (
-                // BUG: AST is incorrect here
-                "fromJson(steps.runs.outputs.data).workflow_runs[0].id",
-                Expr::Call {
-                    func: "fromJson".into(),
-                    args: vec![
-                        Expr::Context("steps.runs.outputs.data".into()).into(),
-                        Expr::Context("workflow_runs[0].id".into()).into(),
-                    ]
-                }
-            ),
+            )
         ];
 
         for (case, expr) in cases {

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -330,6 +330,8 @@ mod tests {
             "(true == false) == true",
             "(true == (false || true && (true || false))) == true",
             "(github.actor != 'github-actions[bot]' && github.actor) == 'BrewTestBot'",
+            "foo()[0]",
+            "fromJson(steps.runs.outputs.data).workflow_runs[0].id",
         ];
 
         for case in cases {
@@ -440,7 +442,11 @@ mod tests {
                     op: BinOp::Or, rhs: Expr::Boolean(false).into()
                     }.into()
                 }
-            )
+            ),
+            // (
+            //     "fromJson(steps.runs.outputs.data).workflow_runs[0].id",
+            //     Expr::Boolean(true),
+            // )
         ];
 
         for (case, expr) in cases {

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -87,7 +87,7 @@ impl Expr {
                 }
             }
             Expr::Context { raw, components } if !matches!(components[0], Expr::Call { .. }) => {
-                contexts.push(&raw)
+                contexts.push(raw)
             }
             Expr::BinOp { lhs, op: _, rhs } => {
                 contexts.extend(lhs.contexts());
@@ -444,7 +444,7 @@ mod tests {
                             ).into(),
                         ),
                     ],
-                ).into(),
+                ),
             ),
             (
                 "foo.bar.baz[*]",
@@ -464,7 +464,7 @@ mod tests {
                             Expr::Star.into(),
                         ),
                     ],
-                ).into(),
+                ),
             ),
             (
                 "vegetables.*.ediblePortions",
@@ -474,12 +474,12 @@ mod tests {
                         Expr::ident(
                             "vegetables",
                         ),
-                        Expr::Star.into(),
+                        Expr::Star,
                         Expr::ident(
                             "ediblePortions",
                         ),
                     ],
-                ).into(),
+                ),
             ),
             (
                 // Sanity check for our associativity: the top level Expr here

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -365,6 +365,7 @@ mod tests {
             "(true == false) == true",
             "(true == (false || true && (true || false))) == true",
             "(github.actor != 'github-actions[bot]' && github.actor) == 'BrewTestBot'",
+            "fromJson(steps.runs.outputs.data).workflow_runs[0].id",
         ];
 
         for case in cases {
@@ -413,17 +414,19 @@ mod tests {
             ("foo.bar.baz", Expr::Context("foo.bar.baz".into())),
             (
                 "foo.bar.baz[1][2]",
-                Expr::Index {
-                    parent: Expr::Context("foo.bar.baz".into()).into(),
-                    indices: vec![Expr::Number(1.0), Expr::Number(2.0)],
-                },
+                Expr::Context("foo.bar.baz[1][2]".into()),
+                // Expr::Index {
+                //     parent: Expr::Context("foo.bar.baz".into()).into(),
+                //     indices: vec![Expr::Number(1.0), Expr::Number(2.0)],
+                // },
             ),
             (
                 "foo.bar.baz[*]",
-                Expr::Index {
-                    parent: Expr::Context("foo.bar.baz".into()).into(),
-                    indices: vec![Expr::Star],
-                },
+                Expr::Context("foo.bar.baz[*]".into()),
+                // Expr::Index {
+                //     parent: Expr::Context("foo.bar.baz".into()).into(),
+                //     indices: vec![Expr::Star],
+                // },
             ),
             (
                 "vegetables.*.ediblePortions",
@@ -473,7 +476,18 @@ mod tests {
                     op: BinOp::Or, rhs: Expr::Boolean(false).into()
                     }.into()
                 }
-            )
+            ),
+            (
+                // BUG: AST is incorrect here
+                "fromJson(steps.runs.outputs.data).workflow_runs[0].id",
+                Expr::Call {
+                    func: "fromJson".into(),
+                    args: vec![
+                        Expr::Context("steps.runs.outputs.data".into()).into(),
+                        Expr::Context("workflow_runs[0].id".into()).into(),
+                    ]
+                }
+            ),
         ];
 
         for (case, expr) in cases {

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -257,6 +257,12 @@ fn template_injection() -> Result<()> {
         .workflow(workflow_under_test("template-injection/static-env.yml"))
         .run()?);
 
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "template-injection/issue-339-repro.yml"
+        ))
+        .run()?);
+
     Ok(())
 }
 

--- a/tests/snapshots/snapshot__template_injection-6.snap
+++ b/tests/snapshots/snapshot__template_injection-6.snap
@@ -1,0 +1,18 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"template-injection/issue-339-repro.yml\")).run()?"
+snapshot_kind: text
+---
+info[template-injection]: code injection via template expansion
+  --> @@INPUT@@:27:9
+   |
+27 |         - name: "Record run id"
+   |           --------------------- info: this step
+28 |           id: run-id
+29 | /         run: |
+30 | |           echo "run-id=${{ fromJson(steps.runs.outputs.data).workflow_runs[0].id }}" >> "$GITHUB_OUTPUT"
+   | |_________________________________________________________________________________________________________- info: steps.runs.outputs.data may expand into attacker-controllable code
+   |
+   = note: audit confidence → Low
+
+1 finding: 0 unknown, 1 informational, 0 low, 0 medium, 0 high

--- a/tests/test-data/template-injection/issue-339-repro.yml
+++ b/tests/test-data/template-injection/issue-339-repro.yml
@@ -1,0 +1,30 @@
+# minimized from https://github.com/woodruffw/zizmor/issues/339
+
+name: "Publish"
+
+on:
+  repository_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  find-run:
+    name: "Find latest kit.yml run"
+    runs-on: "ubuntu-latest"
+    outputs:
+      run-id: ${{ steps.run-id.outputs.run-id }}
+
+    steps:
+      - name: "Find latest kit.yml run"
+        id: runs
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
+        with:
+          route: GET /repos/nedbat/coveragepy/actions/workflows/kit.yml/runs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Record run id"
+        id: run-id
+        run: |
+          echo "run-id=${{ fromJson(steps.runs.outputs.data).workflow_runs[0].id }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
~~WIP;~~ These grammar changes mean the syntax tree itself is different, so I need to update the walk as well.

Fixes #339.