### PR TITLE
feat: adds more publish-aware actions to cache-audit

### DIFF
--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -114,11 +114,29 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<CacheAwareAction>> = LazyLock::ne
 /// In the future we can retrieve this list from the static API
 static KNOWN_PUBLISHER_ACTIONS: LazyLock<Vec<Uses>> = LazyLock::new(|| {
     vec![
+        // Public packages and/or binary distribution channels
         Uses::from_step("pypa/gh-action-pypi-publish").unwrap(),
-        Uses::from_step("softprops/action-gh-release").unwrap(),
         Uses::from_step("rubygems/release-gem").unwrap(),
-        Uses::from_step("goreleaser/goreleaser-action").unwrap(),
         Uses::from_step("jreleaser/release-action").unwrap(),
+        Uses::from_step("goreleaser/goreleaser-action").unwrap(),
+        // Github releases
+        Uses::from_step("softprops/action-gh-release").unwrap(),
+        Uses::from_step("release-drafter/release-drafter").unwrap(),
+        Uses::from_step("googleapis/release-please-action").unwrap(),
+        // Container registries
+        Uses::from_step("docker/build-push-action").unwrap(),
+        Uses::from_step("redhat-actions/push-to-registry").unwrap(),
+        // Cloud + Edge providers
+        Uses::from_step("aws-actions/amazon-ecs-deploy-task-definition ").unwrap(),
+        Uses::from_step("aws-actions/aws-cloudformation-github-deploy").unwrap(),
+        Uses::from_step("Azure/aci-deploy").unwrap(),
+        Uses::from_step("Azure/container-apps-deploy-action").unwrap(),
+        Uses::from_step("Azure/functions-action").unwrap(),
+        Uses::from_step("Azure/sql-action").unwrap(),
+        Uses::from_step("cloudflare/wrangler-action").unwrap(),
+        Uses::from_step("google-github-actions/deploy-appengine").unwrap(),
+        Uses::from_step("google-github-actions/deploy-cloudrun").unwrap(),
+        Uses::from_step("google-github-actions/deploy-cloud-functions").unwrap(),
     ]
 });
 


### PR DESCRIPTION
Another contribution to #334 

I investigated the Github Marketplace along with public Github orgs out there to improve a a bit the list of publisher-like Actions. Added Actions from Docker, GCP, AWS, Azure and a few popular ones used to publish binaries to Github releases.

Should we document this in the official docs, maybe?