### PR TITLE
Updates astral-sh/setup-uv action to v5

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -333,7 +333,7 @@ jobs:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v5
 
       - name: Run zizmor 🌈
         run: uvx zizmor --format sarif . > results.sarif # (2)!


### PR DESCRIPTION
[Caught by dependabot](https://github.com/colindean/transmission-blocklist/pull/9) moments after I set it up in one of my repos.