### PR TITLE
fix: setup-go's cache-control is OptOut

### DIFF
--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -54,8 +54,8 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<CacheAwareAction>> = LazyLock::ne
         // https://github.com/actions/setup-go/blob/main/action.yml
         CacheAwareAction {
             uses: Uses::from_step("actions/setup-go").unwrap(),
-            cache_control: CacheControl::OptOut("cache"),
-            control_value: ControlValue::String,
+            cache_control: CacheControl::OptIn("cache"),
+            control_value: ControlValue::Boolean,
             caching_by_default: true,
         },
         // https://github.com/actions/setup-node/blob/main/action.yml

--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -54,7 +54,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<CacheAwareAction>> = LazyLock::ne
         // https://github.com/actions/setup-go/blob/main/action.yml
         CacheAwareAction {
             uses: Uses::from_step("actions/setup-go").unwrap(),
-            cache_control: CacheControl::OptIn("cache"),
+            cache_control: CacheControl::OptOut("cache"),
             control_value: ControlValue::String,
             caching_by_default: true,
         },

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -324,6 +324,10 @@ fn cache_poisoning() -> Result<()> {
         .workflow(workflow_under_test("cache-poisoning/publisher-step.yml"))
         .run()?);
 
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("cache-poisoning/issue-343-repro.yml"))
+        .run()?);
+
     Ok(())
 }
 

--- a/tests/snapshots/snapshot__cache_poisoning-11.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-11.snap
@@ -1,0 +1,60 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"cache-poisoning/issue-343-repro.yml\")).run()?"
+snapshot_kind: text
+---
+error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+  --> @@INPUT@@:5:1
+   |
+ 5 | / on:
+ 6 | |   push:
+ 7 | |     tags:
+ 8 | |       - "v*.*.*"
+   | |________________^ generally used when publishing artifacts generated at runtime
+ 9 |
+...
+24 |         - name: true-positive-2
+25 |           uses: actions/setup-go@v5
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
+   |
+   = note: audit confidence → Low
+
+error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+  --> @@INPUT@@:5:1
+   |
+ 5 | / on:
+ 6 | |   push:
+ 7 | |     tags:
+ 8 | |       - "v*.*.*"
+   | |________________^ generally used when publishing artifacts generated at runtime
+ 9 |
+...
+31 |           uses: actions/setup-go@v5
+32 | /         with:
+33 | |           go-version: stable
+34 | |           cache: true
+35 | |
+36 | |       # Finding because setup enables cache explicitly
+   | |______________________________________________________^ opt-in for caching here
+   |
+   = note: audit confidence → Low
+
+error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+  --> @@INPUT@@:5:1
+   |
+ 5 | / on:
+ 6 | |   push:
+ 7 | |     tags:
+ 8 | |       - "v*.*.*"
+   | |________________^ generally used when publishing artifacts generated at runtime
+ 9 |
+...
+38 |           uses: actions/setup-go@v5
+39 | /         with:
+40 | |           go-version: stable
+41 | |           cache: "true"
+   | |________________________^ opt-in for caching here
+   |
+   = note: audit confidence → Low
+
+7 findings (4 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 3 high

--- a/tests/test-data/cache-poisoning/issue-343-repro.yml
+++ b/tests/test-data/cache-poisoning/issue-343-repro.yml
@@ -1,0 +1,41 @@
+# minimized from https://github.com/woodruffw/zizmor/pull/343
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # No finding, since cache is explicitly disabled.
+      - name: true-negative-1
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: false
+
+      # Finding because setup-go enables cache by default
+      - name: true-positive-2
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      # Finding because setup enables cache explicitly
+      - name: true-positive-2
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      # Finding because setup enables cache explicitly
+      - name: true-positive-3
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: "true"


### PR DESCRIPTION
`setup-go`'s caching is on by default and opt-out with `cache=false`, https://github.com/actions/setup-go?tab=readme-ov-file#v4

Fixes [this](https://github.com/jmelahman/connections/blob/master/.github/workflows/release.yml) false positive,
![screenshot-2024-12-21-09-34-42](https://github.com/user-attachments/assets/166a6d0b-4e23-48f3-aab5-cfc6ce977cbf)
