### PR TITLE
feat: augments the list of cache-aware action in cache-audit

### DIFF
--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -126,9 +126,62 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<CacheAwareAction>> = LazyLock::ne
             control_value: CacheControlValue::Boolean,
             caching_by_default: false,
         }),
+        // https://github.com/mlugg/setup-zig/blob/main/action.yml
+        CacheAwareAction::Configurable(ControllableCacheAction {
+            uses: Uses::from_step("mlugg/setup-zig").unwrap(),
+            control_input: CacheControlInput::OptIn("use-cache"),
+            control_value: CacheControlValue::Boolean,
+            caching_by_default: true,
+        }),
+        // https://github.com/oven-sh/setup-bun/blob/main/action.yml
+        CacheAwareAction::Configurable(ControllableCacheAction {
+            uses: Uses::from_step("oven-sh/setup-bun").unwrap(),
+            control_input: CacheControlInput::OptOut("no-cache"),
+            control_value: CacheControlValue::Boolean,
+            caching_by_default: true,
+        }),
+        // https://github.com/DeterminateSystems/magic-nix-cache-action/blob/main/action.yml
+        CacheAwareAction::Configurable(ControllableCacheAction {
+            uses: Uses::from_step("DeterminateSystems/magic-nix-cache-action").unwrap(),
+            control_input: CacheControlInput::OptIn("use-gha-cache"),
+            control_value: CacheControlValue::Boolean,
+            caching_by_default: true,
+        }),
+        // https://github.com/graalvm/setup-graalvm/blob/main/action.yml
+        CacheAwareAction::Configurable(ControllableCacheAction {
+            uses: Uses::from_step("graalvm/setup-graalvm").unwrap(),
+            control_input: CacheControlInput::OptIn("cache"),
+            control_value: CacheControlValue::String,
+            caching_by_default: false,
+        }),
+        // https://github.com/gradle/actions/blob/main/setup-gradle/action.yml
+        CacheAwareAction::Configurable(ControllableCacheAction {
+            uses: Uses::from_step("gradle/actions/setup-gradle").unwrap(),
+            control_input: CacheControlInput::OptOut("cache-disabled"),
+            control_value: CacheControlValue::Boolean,
+            caching_by_default: true,
+        }),
+        // https://github.com/docker/setup-buildx-action/blob/master/action.yml
+        CacheAwareAction::Configurable(ControllableCacheAction {
+            uses: Uses::from_step("docker/setup-buildx-action").unwrap(),
+            control_input: CacheControlInput::OptIn("cache-binary"),
+            control_value: CacheControlValue::Boolean,
+            caching_by_default: true,
+        }),
+        // https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/action.yml
+        CacheAwareAction::Configurable(ControllableCacheAction {
+            uses: Uses::from_step("actions-rust-lang/setup-rust-toolchain").unwrap(),
+            control_input: CacheControlInput::OptIn("cache"),
+            control_value: CacheControlValue::Boolean,
+            caching_by_default: true,
+        }),
         // https://github.com/Mozilla-Actions/sccache-action/blob/main/action.yml
         CacheAwareAction::NotConfigurable(
             Uses::from_step("Mozilla-Actions/sccache-action").unwrap(),
+        ),
+        // https://github.com/nix-community/cache-nix-action/blob/main/action.yml
+        CacheAwareAction::NotConfigurable(
+            Uses::from_step("nix-community/cache-nix-action").unwrap(),
         ),
     ]
 });


### PR DESCRIPTION
Another follow-up for #334.

Extends the list of known cache-aware Actions with the following

- https://github.com/mlugg/setup-zig
- https://github.com/oven-sh/setup-bun
- https://github.com/graalvm/setup-graalvm
- https://github.com/gradle/actions/blob/main/setup-gradle
- https://github.com/DeterminateSystems/magic-nix-cache-action
- https://github.com/docker/setup-buildx-action
- https://github.com/actions-rust-lang/setup-rust-toolchain
- https://github.com/nix-community/cache-nix-action

I did a search in both Github Marketplace and dependends of [actions/toolkit/cache](https://github.com/actions/toolkit/network/dependents?package_id=UGFja2FnZS0xMTc3OTQzMDA0) and filtered some of the most popular ones. 
