### PR TITLE
feat: detects push to release branches in cache-poisoning

### DIFF
--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -334,6 +334,12 @@ fn cache_poisoning() -> Result<()> {
         ))
         .run()?);
 
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/workflow-release-branch-trigger.yml"
+        ))
+        .run()?);
+
     Ok(())
 }
 

--- a/tests/snapshots/snapshot__cache_poisoning-13.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-13.snap
@@ -1,0 +1,22 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"cache-poisoning/workflow-release-branch-trigger.yml\")).run()?"
+snapshot_kind: text
+---
+error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+  --> @@INPUT@@:1:1
+   |
+ 1 | / on:
+ 2 | |   push:
+ 3 | |     branches:
+ 4 | |       - 'release-v2.0.0'
+   | |________________________^ generally used when publishing artifacts generated at runtime
+ 5 |
+...
+15 |         - name: Setup CI caching
+16 |           uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
+   |
+   = note: audit confidence → Low
+
+1 finding: 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/tests/test-data/cache-poisoning/workflow-release-branch-trigger.yml
+++ b/tests/test-data/cache-poisoning/workflow-release-branch-trigger.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - 'release-v2.0.0'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Project Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+      - name: Setup CI caching
+        uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+
+      - name: Publish on crates.io
+        run: cargo publish --token ${{ secrets.CRATESIO_PUBLISH_TOKEN }}


### PR DESCRIPTION
One more follow-up for #334

We now detect at least one common pattern for Workflows triggered with `push/branches`. Deploying when pushing to a convention release branch is quite common, and this change sets the stage to detect other similar branch filters in the future.

There is at least one additional PR to before finishing #334, raising it asap!