### PR TITLE
feat: github-env: use tree-sitter queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,6 +3042,7 @@ dependencies = [
  "serde_json",
  "serde_json_path",
  "serde_yaml",
+ "streaming-iterator",
  "terminal-link",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1.0.216", features = ["derive"] }
 serde-sarif = "0.7.0"
 serde_json = "1.0.134"
 serde_yaml = "0.9.34"
+streaming-iterator = "0.1.9"
 terminal-link = "0.1.0"
 tokio = { version = "1.42.0", features = ["rt-multi-thread"] }
 tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1.0.216", features = ["derive"] }
 serde-sarif = "0.7.0"
 serde_json = "1.0.134"
 serde_yaml = "0.9.34"
+# TODO remove pending https://github.com/tree-sitter/tree-sitter/pull/4034
 streaming-iterator = "0.1.9"
 terminal-link = "0.1.0"
 tokio = { version = "1.42.0", features = ["rt-multi-thread"] }

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -61,7 +61,7 @@ const BASH_PIPELINE_QUERY: &str = r#"
 "#;
 
 impl GitHubEnv {
-    fn echo_arg_is_safe<'a>(&self, arg: &QueryCapture<'_>) -> bool {
+    fn echo_arg_is_safe(&self, arg: &QueryCapture<'_>) -> bool {
         // Different cases we handle:
         // * `word` and `raw_string` are for `echo foo` and `echo 'foo'`
         //    respectively
@@ -147,7 +147,7 @@ impl GitHubEnv {
         ];
 
         for (query, span_idx) in queries {
-            let matches = self.query(&query, &mut cursor, &tree, script_body);
+            let matches = self.query(query, &mut cursor, &tree, script_body);
 
             matches.for_each(|mat| {
                 for cap in mat.captures {

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -80,7 +80,6 @@ impl GitHubEnv {
         arg.node.kind() == "word"
             || arg.node.kind() == "raw_string"
             || (arg.node.named_child_count() == 1
-                // NOTE: infallible unwrap given count check above.
                 && arg.node.named_child(0).map(|c| c.kind()) == Some("string_content"))
     }
 


### PR DESCRIPTION
~~Very WIP.~~

This experimentally replaces the stack-of-nodes approach with hand-written TS queries, which can be more precise about matches and their sub-captures (e.g. allowing us to match only when the RHS is actually a variable expansion).

It also adds some examples of false positives that the previous approach flagged. These FPs aren't likely to occur in the wild, however, so the direct benefit for actual users is pretty small.

The larger impact here is indirect:

* By switching to TS queries, we get full access to match and capture-level spanning information. We had this indirectly with the stack-of-nodes approach, but the query language makes it even simpler by giving us capture names 🙂 
* This unblocks a bugfix for #234 which would be challenging to generalize with the previous approach -- we could do it one-off, but doing things at the TS query level gives us more generality.

At the same time, there are some downsides to this approach:

* It's not as elegant (IMO) as the previous approach.
* It's probably slower both at startup and runtime, since each TS query needs to be parsed, evaluated, etc.
* Writing TS queries is a less-ideal DX, since they're a new DSL that isn't highlighted and aren't super easy to debug (I mostly use the tree-sitter playground).

CC @ubiratansoares for thoughts on this approach -- I think it makes things somewhat easier/more general overall, but it has downsides. I'm curious what you think about these tradeoffs 🙂 

(I also still need to do the same for the PowerShell codepath.)