### PR TITLE
feat: ref-confusion now supports composite actions

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -357,9 +357,9 @@ the action if one is available, or remove the action's usage entirely.
 
 ## `ref-confusion`
 
-| Type     | Examples            | Introduced in | Works offline  | Enabled by default |
-|----------|---------------------|---------------|----------------|--------------------|
-| Workflow  | [ref-confusion.yml] | v0.1.0        | ❌             | ✅                 |
+| Type             | Examples            | Introduced in | Works offline  | Enabled by default |
+|------------------|---------------------|---------------|----------------|--------------------|
+| Workflow, Action | [ref-confusion.yml] | v0.1.0        | ❌             | ✅                 |
 
 
 [ref-confusion.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/ref-confusion.yml

--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -12,6 +12,8 @@ use anyhow::{anyhow, Result};
 use github_actions_models::workflow::Job;
 
 use super::{audit_meta, Audit};
+use crate::finding::Finding;
+use crate::models::CompositeStep;
 use crate::{
     finding::{Confidence, Severity},
     github_api,
@@ -111,6 +113,31 @@ impl Audit for RefConfusion {
                     }
                 }
             }
+        }
+
+        Ok(findings)
+    }
+
+    fn audit_composite_step<'a>(&self, step: &CompositeStep<'a>) -> Result<Vec<Finding<'a>>> {
+        let mut findings = vec![];
+
+        let Some(Uses::Repository(uses)) = step.uses() else {
+            return Ok(findings);
+        };
+
+        if self.confusable(&uses)? {
+            findings.push(
+                Self::finding()
+                    .severity(Severity::Medium)
+                    .confidence(Confidence::High)
+                    .add_location(
+                        step.location()
+                            .primary()
+                            .with_keys(&["uses".into()])
+                            .annotated(REF_CONFUSION_ANNOTATION),
+                    )
+                    .build(step.action())?,
+            );
         }
 
         Ok(findings)


### PR DESCRIPTION
Contributes to #350 

This one should be trivial, since most of machinery was in place (including the handy `RefConfusion::confusable` method) 😄

I miss here the good vibes after running snapshot tests locally, but #306 will bring the chance to catch up for this audit 🙂