### PR TITLE
docs: ditches beta warning from static website

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,12 +5,6 @@
 [![Packaging status](https://repology.org/badge/tiny-repos/zizmor.svg)](https://repology.org/project/zizmor/versions)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/woodruffw?style=flat&logo=githubsponsors&labelColor=white&color=white)](https://github.com/sponsors/woodruffw)
 
-!!! warning
-
-    `zizmor` is currently in beta. You will encounter bugs; [please file them]!
-
-[please file them]: https://github.com/woodruffw/zizmor/issues/new?assignees=&labels=bug%2Ctriage&projects=&template=bug-report.yml&title=%5BBUG%5D%3A+
-
 :rainbow: Hello, and welcome to `zizmor`'s documentation! :rainbow:
 
 `zizmor` is a static analysis tool for GitHub Actions. It can find


### PR DESCRIPTION
A follow-up for #377 . 

Just checked `zizmor` website and there is one beta warning  left at `docs/index.md`. Removed just in case 😄