### PR TITLE
refactor: generalize coordinate usage semantics

### DIFF
--- a/src/models/coordinate.rs
+++ b/src/models/coordinate.rs
@@ -45,13 +45,21 @@ impl UsesCoordinate<'_> {
     ///
     /// Intuitively: `disable-cache: true` is an opt-in to `disable-cache`, but an opt-out
     /// of caching. So a coordinate that checks for cache usage inverts the naive result.
-    fn declared_usage(&self, value: &EnvValue, field_type: &ControlFieldType) -> Option<Usage> {
+    fn declared_usage(
+        &self,
+        value: &EnvValue,
+        toggle: &Toggle,
+        field_type: &ControlFieldType,
+    ) -> Option<Usage> {
         match value.to_string().as_str() {
-            "true" if matches!(field_type, ControlFieldType::Boolean) => Some(Usage::DirectOptIn),
-            "false" if matches!(field_type, ControlFieldType::Boolean) => {
-                // Explicitly opts out from caching
-                None
-            }
+            "true" if matches!(field_type, ControlFieldType::Boolean) => match toggle {
+                Toggle::OptIn => Some(Usage::DirectOptIn),
+                Toggle::OptOut => None,
+            },
+            "false" if matches!(field_type, ControlFieldType::Boolean) => match toggle {
+                Toggle::OptIn => None,
+                Toggle::OptOut => Some(Usage::DirectOptIn),
+            },
             other => match ExplicitExpr::from_curly(other) {
                 None if matches!(field_type, ControlFieldType::String) => Some(Usage::DirectOptIn),
                 None => None,
@@ -92,16 +100,15 @@ impl UsesCoordinate<'_> {
                     Some(field_value) => {
                         // The declared usage is whatever the user explicitly configured,
                         // which might be inverted if the semantics are opt-out instead.
-                        let declared_usage =
-                            self.declared_usage(field_value, &control.field_type)?;
+                        self.declared_usage(field_value, &control.toggle, &control.field_type)
 
-                        match declared_usage {
-                            Usage::DirectOptIn => match control.toggle {
-                                Toggle::OptIn => Some(declared_usage),
-                                Toggle::OptOut => None,
-                            },
-                            _ => Some(declared_usage),
-                        }
+                        // match declared_usage {
+                        //     Usage::DirectOptIn => match control.toggle {
+                        //         Toggle::OptIn => Some(declared_usage),
+                        //         Toggle::OptOut => None,
+                        //     },
+                        //     _ => Some(declared_usage),
+                        // }
                     }
                     None => {
                         // If the controlling field is not present, the default dictates the semantics.
@@ -165,4 +172,112 @@ pub(crate) enum Usage {
     DirectOptIn,
     DefaultActionBehaviour,
     Always,
+}
+
+#[cfg(test)]
+mod tests {
+    use github_actions_models::workflow::job::Step;
+
+    use crate::models::coordinate::{Control, ControlFieldType, Toggle, Usage};
+
+    use super::{StepCommon, Uses, UsesCoordinate};
+
+    // Test-only trait impl.
+    impl StepCommon for Step {
+        fn env_is_static(&self, _name: &str) -> bool {
+            unimplemented!()
+        }
+
+        fn strategy(&self) -> Option<&github_actions_models::workflow::job::Strategy> {
+            unimplemented!()
+        }
+
+        fn uses(&self) -> Option<Uses> {
+            match &self.body {
+                github_actions_models::workflow::job::StepBody::Uses { uses, .. } => {
+                    Some(Uses::from_step(&uses).unwrap())
+                }
+                github_actions_models::workflow::job::StepBody::Run { .. } => None,
+            }
+        }
+
+        fn with(&self) -> Option<&github_actions_models::common::Env> {
+            match &self.body {
+                github_actions_models::workflow::job::StepBody::Uses { uses: _, with } => {
+                    Some(with)
+                }
+                github_actions_models::workflow::job::StepBody::Run { .. } => None,
+            }
+        }
+    }
+
+    #[test]
+    fn test_usage() {
+        // Trivial case: no usage is possible, since the coordinate's `uses:`
+        // does not match the step.
+        let coord = UsesCoordinate::NotConfigurable(Uses::from_common("foo/bar").unwrap());
+        let step: Step = serde_yaml::from_str("uses: not/thesame").unwrap();
+        assert_eq!(coord.usage(&step), None);
+
+        // Trivial cases: coordinate is not configurable and matches the `uses:`.
+        for step in &["uses: foo/bar", "uses: foo/bar@v1"] {
+            let step: Step = serde_yaml::from_str(step).unwrap();
+            assert_eq!(coord.usage(&step), Some(Usage::Always));
+        }
+
+        // Coordinate `uses:` matches but is not enabled by default and is
+        // missing the needed control.
+        let coord = UsesCoordinate::Configurable {
+            uses: Uses::from_common("foo/bar").unwrap(),
+            control: Control::new(Toggle::OptIn, "set-me", ControlFieldType::Boolean),
+            enabled_by_default: false,
+        };
+        let step: Step = serde_yaml::from_str("uses: foo/bar").unwrap();
+        assert_eq!(coord.usage(&step), None);
+
+        // Coordinate `uses:` matches and is explicitly toggled on.
+        let step: Step = serde_yaml::from_str("uses: foo/bar\nwith:\n  set-me: true").unwrap();
+        assert_eq!(coord.usage(&step), Some(Usage::DirectOptIn));
+
+        // Coordinate `uses:` matches but is explicitly toggled off.
+        let step: Step = serde_yaml::from_str("uses: foo/bar\nwith:\n  set-me: false").unwrap();
+        assert_eq!(coord.usage(&step), None);
+
+        // Coordinate `uses:` matches and is enabled by default.
+        let coord = UsesCoordinate::Configurable {
+            uses: Uses::from_common("foo/bar").unwrap(),
+            control: Control::new(Toggle::OptIn, "set-me", ControlFieldType::Boolean),
+            enabled_by_default: true,
+        };
+        let step: Step = serde_yaml::from_str("uses: foo/bar").unwrap();
+        assert_eq!(coord.usage(&step), Some(Usage::DefaultActionBehaviour));
+
+        // Coordinate `uses:` matches and is explicitly toggled on.
+        let step: Step = serde_yaml::from_str("uses: foo/bar\nwith:\n  set-me: true").unwrap();
+        assert_eq!(coord.usage(&step), Some(Usage::DirectOptIn));
+
+        // Coordinate `uses:` matches but is explicitly toggled off, despite default enablement.
+        let step: Step = serde_yaml::from_str("uses: foo/bar\nwith:\n  set-me: false").unwrap();
+        assert_eq!(coord.usage(&step), None);
+
+        // Coordinate `uses:` matches and has an opt-out toggle, which does not affect
+        // the default.
+        let coord = UsesCoordinate::Configurable {
+            uses: Uses::from_common("foo/bar").unwrap(),
+            control: Control::new(Toggle::OptOut, "disable-cache", ControlFieldType::Boolean),
+            enabled_by_default: false,
+        };
+        let step: Step = serde_yaml::from_str("uses: foo/bar").unwrap();
+        assert_eq!(coord.usage(&step), None);
+
+        // Coordinate `uses:` matches and the opt-out inverts the match, clearing it.
+        let step: Step =
+            serde_yaml::from_str("uses: foo/bar\nwith:\n  disable-cache: true").unwrap();
+        assert_eq!(coord.usage(&step), None);
+
+        // Coordinate `uses:` matches and the opt-out inverts the match, clearing it.
+        let step: Step =
+            serde_yaml::from_str("uses: foo/bar\nwith:\n  disable-cache: false").unwrap();
+        assert_eq!(coord.usage(&step), Some(Usage::DirectOptIn));
+    }
 }

--- a/src/models/coordinate.rs
+++ b/src/models/coordinate.rs
@@ -116,18 +116,18 @@ impl UsesCoordinate<'_> {
 }
 
 pub(crate) enum Toggle {
-    /// Opt-in means that cache is **enabled** when the control value matches.
+    /// Opt-in means that usage is **enabled** when the control value matches.
     OptIn,
-    /// Opt-out means that cache is **disabled** when the control value matches.
+    /// Opt-out means that usage is **disabled** when the control value matches.
     OptOut,
 }
 
-/// The value type that controls the activation/deactivation of caching
+/// The type of value that controls the step's behavior.
 #[derive(PartialEq)]
 pub(crate) enum ControlFieldType {
-    /// The caching behavior is controlled by a boolean field, e.g. `cache: true`.
+    /// The behavior is controlled by a boolean field, e.g. `cache: true`.
     Boolean,
-    /// The caching behavior is controlled by a string field, e.g. `cache: "pip"`.
+    /// The behavior is controlled by a string field, e.g. `cache: "pip"`.
     String,
 }
 


### PR DESCRIPTION
See #378; follows #383.

This generalizes the "coordinate usage" semantics from caching actions to anything that might be configurable.

Needs additional tests.