### PR TITLE
fix: cache-poisoning: handle non-pushing docker-push-action

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,8 @@ of `zizmor`.
 ### Fixed
 
 * `workflow_call.secrets` keys with missing values are now parsed correctly (#388)
+* The [cache-poisoning] audit no longer incorrectly treats `docker/build-push-action` as
+  a publishing workflow is `push: false` is explicitly set (#389)
 
 ## v1.0.0
 

--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -123,31 +123,53 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<UsesCoordinate>> = LazyLock::new(
 
 /// A list of well-know publisher actions
 /// In the future we can retrieve this list from the static API
-static KNOWN_PUBLISHER_ACTIONS: LazyLock<Vec<Uses>> = LazyLock::new(|| {
+static KNOWN_PUBLISHER_ACTIONS: LazyLock<Vec<UsesCoordinate>> = LazyLock::new(|| {
     vec![
         // Public packages and/or binary distribution channels
-        Uses::from_step("pypa/gh-action-pypi-publish").unwrap(),
-        Uses::from_step("rubygems/release-gem").unwrap(),
-        Uses::from_step("jreleaser/release-action").unwrap(),
-        Uses::from_step("goreleaser/goreleaser-action").unwrap(),
+        UsesCoordinate::NotConfigurable(Uses::from_step("pypa/gh-action-pypi-publish").unwrap()),
+        UsesCoordinate::NotConfigurable(Uses::from_step("rubygems/release-gem").unwrap()),
+        UsesCoordinate::NotConfigurable(Uses::from_step("jreleaser/release-action").unwrap()),
+        UsesCoordinate::NotConfigurable(Uses::from_step("goreleaser/goreleaser-action").unwrap()),
         // Github releases
-        Uses::from_step("softprops/action-gh-release").unwrap(),
-        Uses::from_step("release-drafter/release-drafter").unwrap(),
-        Uses::from_step("googleapis/release-please-action").unwrap(),
+        UsesCoordinate::NotConfigurable(Uses::from_step("softprops/action-gh-release").unwrap()),
+        UsesCoordinate::NotConfigurable(
+            Uses::from_step("release-drafter/release-drafter").unwrap(),
+        ),
+        UsesCoordinate::NotConfigurable(
+            Uses::from_step("googleapis/release-please-action").unwrap(),
+        ),
         // Container registries
-        Uses::from_step("docker/build-push-action").unwrap(),
-        Uses::from_step("redhat-actions/push-to-registry").unwrap(),
+        UsesCoordinate::Configurable {
+            uses: Uses::from_step("docker/build-push-action").unwrap(),
+            control: Control::new(Toggle::OptIn, "push", ControlFieldType::Boolean),
+            enabled_by_default: true,
+        },
+        UsesCoordinate::NotConfigurable(
+            Uses::from_step("redhat-actions/push-to-registry").unwrap(),
+        ),
         // Cloud + Edge providers
-        Uses::from_step("aws-actions/amazon-ecs-deploy-task-definition ").unwrap(),
-        Uses::from_step("aws-actions/aws-cloudformation-github-deploy").unwrap(),
-        Uses::from_step("Azure/aci-deploy").unwrap(),
-        Uses::from_step("Azure/container-apps-deploy-action").unwrap(),
-        Uses::from_step("Azure/functions-action").unwrap(),
-        Uses::from_step("Azure/sql-action").unwrap(),
-        Uses::from_step("cloudflare/wrangler-action").unwrap(),
-        Uses::from_step("google-github-actions/deploy-appengine").unwrap(),
-        Uses::from_step("google-github-actions/deploy-cloudrun").unwrap(),
-        Uses::from_step("google-github-actions/deploy-cloud-functions").unwrap(),
+        UsesCoordinate::NotConfigurable(
+            Uses::from_step("aws-actions/amazon-ecs-deploy-task-definition ").unwrap(),
+        ),
+        UsesCoordinate::NotConfigurable(
+            Uses::from_step("aws-actions/aws-cloudformation-github-deploy").unwrap(),
+        ),
+        UsesCoordinate::NotConfigurable(Uses::from_step("Azure/aci-deploy").unwrap()),
+        UsesCoordinate::NotConfigurable(
+            Uses::from_step("Azure/container-apps-deploy-action").unwrap(),
+        ),
+        UsesCoordinate::NotConfigurable(Uses::from_step("Azure/functions-action").unwrap()),
+        UsesCoordinate::NotConfigurable(Uses::from_step("Azure/sql-action").unwrap()),
+        UsesCoordinate::NotConfigurable(Uses::from_step("cloudflare/wrangler-action").unwrap()),
+        UsesCoordinate::NotConfigurable(
+            Uses::from_step("google-github-actions/deploy-appengine").unwrap(),
+        ),
+        UsesCoordinate::NotConfigurable(
+            Uses::from_step("google-github-actions/deploy-cloudrun").unwrap(),
+        ),
+        UsesCoordinate::NotConfigurable(
+            Uses::from_step("google-github-actions/deploy-cloud-functions").unwrap(),
+        ),
     ]
 });
 
@@ -190,17 +212,11 @@ impl CachePoisoning {
 
     fn detected_well_known_publisher_step(steps: Steps) -> Option<Step> {
         steps.into_iter().find(|step| {
-            let Some(Uses::Repository(target_uses)) = step.uses() else {
-                return false;
-            };
-
-            KNOWN_PUBLISHER_ACTIONS.iter().any(|publisher| {
-                let Uses::Repository(well_known_uses) = publisher else {
-                    return false;
-                };
-
-                target_uses.matches(*well_known_uses)
-            })
+            // TODO: Specialize further here, and produce an appropriate
+            // confidence/persona setting if the usage is conditional.
+            KNOWN_PUBLISHER_ACTIONS
+                .iter()
+                .any(|publisher| publisher.usage(step).is_some())
         })
     }
 

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -350,6 +350,10 @@ fn cache_poisoning() -> Result<()> {
         ))
         .run()?);
 
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("cache-poisoning/issue-378-repro.yml"))
+        .run()?);
+
     Ok(())
 }
 

--- a/tests/snapshots/snapshot__cache_poisoning-14.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-14.snap
@@ -1,0 +1,6 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"cache-poisoning/issue-378-repro.yml\")).run()?"
+snapshot_kind: text
+---
+No findings to report. Good job!

--- a/tests/test-data/cache-poisoning/issue-378-repro.yml
+++ b/tests/test-data/cache-poisoning/issue-378-repro.yml
@@ -1,0 +1,23 @@
+# minimized from https://github.com/woodruffw/zizmor/issues/378
+
+name: issue-378
+
+on: push
+
+jobs:
+  issue-378:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
+        with:
+          cache-binary: true
+
+      - name: Build docker
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # push is explicitly disabled, so this is not a publishing
+          # workflow and therefore no cache-poisoning finding is emitted
+          push: false


### PR DESCRIPTION
This fixes #378: we now use the generalized `UsesCoordinate` to handle `docker/build-push-action` with `push: false`, meaning that we no longer emit a false positive finding in that case.

This also adds a repro testcase, ensuring that we don't regress.