### PR TITLE
feat: github-env audit checks GITHUB_PATH too

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -673,12 +673,17 @@ In general, users should use for [GitHub Actions environment files]
 
 [github-env.yml]: https://github.com/woodruffw/gha-hazmat/blob/main/.github/workflows/github-env.yml
 
-Detects dangerous usages of the `GITHUB_ENV` environment variable.
+Detects dangerous writes to the `GITHUB_ENV` and `GITHUB_PATH` environment variables.
 
 When used in workflows with dangerous triggers (such as `pull_request_target` and `workflow_run`),
-`GITHUB_ENV` can be an arbitrary code execution risk. In particular, if the attacker is able to set
-arbitrary variables or variable contents via `GITHUB_ENV`, they made be able to set `LD_PRELOAD`
-or otherwise induce code execution implicitly within subsequent steps.
+`GITHUB_ENV` and `GITHUB_PATH` can be an arbitrary code execution risk:
+
+* If the attacker is able to set arbitrary variables or variable contents via
+  `GITHUB_ENV`, they may be able to set `LD_PRELOAD` or otherwise induce code
+  execution implicitly within subsequent steps.
+* If the attacker is able to add an arbitrary directory to the `$PATH` via
+  `GITHUB_PATH`, they may be able to execute arbitrary code by shadowing
+  ordinary system executables (such as `ssh`).
 
 Other resources:
 
@@ -689,8 +694,12 @@ Other resources:
 
 ### Remediation
 
-In general, you should avoid setting `GITHUB_ENV` within workflows that are attacker-triggered,
-like `pull_request_target`.
+In general, you should avoid modifying `GITHUB_ENV` and `GITHUB_PATH` within
+sensitive workflows that are attacker-triggered, like `pull_request_target`.
+
+If you absolutely must use `GITHUB_ENV` or `GITHUB_PATH`, avoid passing
+attacker-controlled values into either. Stick with literal strings and
+values computed solely from trusted sources.
 
 If you need to pass state between steps, consider using `GITHUB_OUTPUT` instead.
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,11 @@ of `zizmor`.
 
 ## Upcoming (UNRELEASED)
 
+### Improved
+
+* The [github-env] audit now detects dangerous writes to `GITHUB_PATH`,
+  is more precise, and can produce multiple findings per run block (#391)
+
 ### Fixed
 
 * `workflow_call.secrets` keys with missing values are now parsed correctly (#388)

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -381,5 +381,9 @@ fn github_env() -> Result<()> {
         .workflow(workflow_under_test("github-env/action.yml"))
         .run()?);
 
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("github-env/github-path.yml"))
+        .run()?);
+
     Ok(())
 }

--- a/tests/snapshots/snapshot__github_env-2.snap
+++ b/tests/snapshots/snapshot__github_env-2.snap
@@ -1,0 +1,16 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"github-env/github-path.yml\")).run()?"
+snapshot_kind: text
+---
+error[github-env]: dangerous use of environment file
+  --> @@INPUT@@:12:9
+   |
+12 | /         run: |
+13 | |           message=$(echo "$TITLE" | grep -oP '[{\[][^}\]]+[}\]]' | sed 's/{\|}\|\[\|\]//g')
+14 | |           echo "$message" >> $GITHUB_PATH
+   | |__________________________________________^ write to GITHUB_PATH may allow code execution
+   |
+   = note: audit confidence → Low
+
+2 findings (1 ignored): 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/tests/snapshots/snapshot__github_env.snap
+++ b/tests/snapshots/snapshot__github_env.snap
@@ -3,30 +3,30 @@ source: tests/snapshot.rs
 expression: "zizmor().workflow(workflow_under_test(\"github-env/action.yml\")).run()?"
 snapshot_kind: text
 ---
-error[github-env]: dangerous use of GITHUB_ENV
+error[github-env]: dangerous use of environment file
   --> @@INPUT@@:10:7
    |
 10 | /       run: |
 11 | |         echo "foo=$(bar)" >> $GITHUB_ENV
-   | |________________________________________^ GITHUB_ENV write may allow code execution
+   | |________________________________________^ write to GITHUB_ENV may allow code execution
    |
    = note: audit confidence → Low
 
-error[github-env]: dangerous use of GITHUB_ENV
+error[github-env]: dangerous use of environment file
   --> @@INPUT@@:15:7
    |
 15 | /       run: |
 16 | |         echo "foo=$env:BAR" >> $env:GITHUB_ENV
-   | |______________________________________________^ GITHUB_ENV write may allow code execution
+   | |______________________________________________^ write to $env:GITHUB_ENV may allow code execution
    |
    = note: audit confidence → Low
 
-error[github-env]: dangerous use of GITHUB_ENV
+error[github-env]: dangerous use of environment file
   --> @@INPUT@@:20:7
    |
 20 | /       run: |
 21 | |         echo LIBRARY=%LIBRARY% >> %GITHUB_ENV%
-   | |______________________________________________^ GITHUB_ENV write may allow code execution
+   | |______________________________________________^ write to GITHUB_ENV may allow code execution
    |
    = note: audit confidence → Low
 

--- a/tests/test-data/github-env/github-path.yml
+++ b/tests/test-data/github-env/github-path.yml
@@ -1,0 +1,14 @@
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+
+jobs:
+  vulnerable:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Passes the title around
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          message=$(echo "$TITLE" | grep -oP '[{\[][^}\]]+[}\]]' | sed 's/{\|}\|\[\|\]//g')
+          echo "$message" >> $GITHUB_PATH


### PR DESCRIPTION
This generalizes the `github-env` audit so that it detects `GITHUB_PATH` writes as well, and renders them appropriately. It also generalizes the finding production within the audit, so that multiple findings can be produced per step instead of terminating at the first finding.

Closes #384.