### PR TITLE
fix: template-injection: github.action_path is safe

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -389,3 +389,4 @@ This is one of `zizmor`'s bigger recent releases! Key enhancements include:
 [excessive-permissions]: ./audits.md#excessive-permissions
 [cache-poisoning]: ./audits.md#cache-poisoning
 [github-env]: ./audits.md#github-env
+[template-injection]: ./audits.md#template-injection

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -19,6 +19,8 @@ of `zizmor`.
 * `workflow_call.secrets` keys with missing values are now parsed correctly (#388)
 * The [cache-poisoning] audit no longer incorrectly treats `docker/build-push-action` as
   a publishing workflow is `push: false` is explicitly set (#389)
+* The [template-injection] audit no longer considers `github.action_path`
+  to be a potentially dangerous expansion (#402)
 
 ## v1.0.0
 

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -508,7 +508,7 @@ mod tests {
 
             let uses_github_env = sut.uses_github_env(case, "bash").unwrap();
 
-            assert!(!uses_github_env.is_empty() == *expected, "failed: {case}");
+            assert!(uses_github_env.is_empty() != *expected, "failed: {case}");
         }
     }
 
@@ -594,7 +594,7 @@ mod tests {
 
             let uses_github_env = sut.uses_github_env(case, "pwsh").unwrap();
 
-            assert!(!uses_github_env.is_empty() == *expected, "failed: {case}");
+            assert!(uses_github_env.is_empty() != *expected, "failed: {case}");
         }
     }
 }

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -33,6 +33,8 @@ audit_meta!(
 
 /// Contexts that are believed to be always safe.
 const SAFE_CONTEXTS: &[&str] = &[
+    // The action path is always safe.
+    "github.action_path",
     // The GitHub event name (i.e. trigger) is itself safe.
     "github.event_name",
     // Safe keys within the otherwise generally unsafe github.event context.

--- a/src/models/coordinate.rs
+++ b/src/models/coordinate.rs
@@ -184,7 +184,7 @@ mod tests {
         fn uses(&self) -> Option<Uses> {
             match &self.body {
                 github_actions_models::workflow::job::StepBody::Uses { uses, .. } => {
-                    Some(Uses::from_step(&uses).unwrap())
+                    Some(Uses::from_step(uses).unwrap())
                 }
                 github_actions_models::workflow::job::StepBody::Run { .. } => None,
             }


### PR DESCRIPTION
Fixes a small FP where `github.action_path` would be flagged despite being 100% runner controlled.