### PR TITLE
fix: handle non-trivial shells in github-env

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -21,6 +21,8 @@ of `zizmor`.
   a publishing workflow is `push: false` is explicitly set (#389)
 * The [template-injection] audit no longer considers `github.action_path`
   to be a potentially dangerous expansion (#402)
+* The [github-env] audit no longer skips `run:` steps with non-trivial
+  `shell:` stanzas (#403)
 
 ## v1.0.0
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -508,7 +508,7 @@ impl<'w> Step<'w> {
         Uses::from_step(uses)
     }
 
-    /// Returns the name of the shell used by this step, or `None`
+    /// Returns the the shell used by this step, or `None`
     /// if the shell can't be statically inferred.
     ///
     /// Invariant: panics if the step is not a `run:` step.

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -385,5 +385,9 @@ fn github_env() -> Result<()> {
         .workflow(workflow_under_test("github-env/github-path.yml"))
         .run()?);
 
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("github-env/issue-397-repro.yml"))
+        .run()?);
+
     Ok(())
 }

--- a/tests/snapshots/snapshot__github_env-3.snap
+++ b/tests/snapshots/snapshot__github_env-3.snap
@@ -1,0 +1,16 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"github-env/issue-397-repro.yml\")).run()?"
+snapshot_kind: text
+---
+error[github-env]: dangerous use of environment file
+  --> @@INPUT@@:12:9
+   |
+12 | /         run: |
+13 | |           message=$(echo "$TITLE" | grep -oP '[{\[][^}\]]+[}\]]' | sed 's/{\|}\|\[\|\]//g')
+14 | |           echo "$message" >> $GITHUB_PATH
+   | |_________________________________________^ write to GITHUB_PATH may allow code execution
+   |
+   = note: audit confidence → Low
+
+2 findings (1 ignored): 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/tests/test-data/github-env/issue-397-repro.yml
+++ b/tests/test-data/github-env/issue-397-repro.yml
@@ -1,0 +1,16 @@
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+
+jobs:
+  issue-397-repro:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Passes the title around
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          message=$(echo "$TITLE" | grep -oP '[{\[][^}\]]+[}\]]' | sed 's/{\|}\|\[\|\]//g')
+          echo "$message" >> $GITHUB_PATH
+        # should be handled as bash
+        shell: /bin/bash


### PR DESCRIPTION
This normalizes the shell before we match it, allowing us to handle cases like in #397.

Fixes #397.