### PR TITLE
fix: template-injection: github.server_url is safe

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,11 @@ of `zizmor`.
 * **New audit**: [secrets-inherit] detects use of `secrets: inherit` with
   reusable workflow calls (#408)
 
+### Fixed
+
+* The [template-injection] audit no longer consider `github.server_url`
+  dangerous (#412)
+
 ## v1.0.1
 
 This is a small quality and bugfix release. Thank you to everybody

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -57,6 +57,9 @@ const SAFE_CONTEXTS: &[&str] = &[
     "github.run_attempt",
     "github.run_id",
     "github.run_number",
+    // Typically something like `https://github.com`; you have bigger problems if
+    // this is attacker-controlled.
+    "github.server_url",
     // Always a 40-char SHA-1 reference.
     "github.sha",
     // Like `secrets.*`: not safe to expose, but safe to interpolate.


### PR DESCRIPTION
Fixes another FP from an always-safe context.

h/t @sharkdp @AlexWaygood

See: https://github.com/astral-sh/ruff/pull/15361