### PR TITLE
fix: update to use static link for PyPI display

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 `zizmor` is a static analysis tool for GitHub Actions. It can find
 many common security issues in typical GitHub Actions CI/CD setups.
 
-![zizmor demo](./docs/assets/zizmor-demo.gif)
+![zizmor demo](https://raw.githubusercontent.com/woodruffw/zizmor/main/docs/assets/zizmor-demo.gif)
 
 See [`zizmor`'s documentation](https://woodruffw.github.io/zizmor/)
 for [installation steps], as well as a [quickstart] and


### PR DESCRIPTION
currently the demo link on pypi is not working, updating to use a static link

<img width="841" alt="image" src="https://github.com/user-attachments/assets/4479a1b8-2776-4b8f-93fc-4ced31914696" />
