### PR TITLE
refactor: add StepBodyCommon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,8 +617,7 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 [[package]]
 name = "github-actions-models"
 version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890f2af630615f46ba8240107ef72742ccff7254209bd75678c3896393739371"
+source = "git+https://github.com/woodruffw/github-actions-models?branch=ww/uses#495835c882d8a6dc6ce729297983fd6382b42ccb"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,8 +616,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "github-actions-models"
-version = "0.18.0"
-source = "git+https://github.com/woodruffw/github-actions-models?branch=ww/uses#495835c882d8a6dc6ce729297983fd6382b42ccb"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9576dac15088d565d47b67d09bd9fd9f0d84bda4b0d34af91ab55327f4c2d0"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap-verbosity-flag = { version = "3.0.2", features = [
 ], default-features = false }
 etcetera = "0.8.0"
 flate2 = "1.0.35"
-github-actions-models = "0.18.0"
+github-actions-models = { git = "https://github.com/woodruffw/github-actions-models", branch = "ww/uses" }
 http-cache-reqwest = "0.15.0"
 human-panic = "2.0.1"
 indexmap = "2.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap-verbosity-flag = { version = "3.0.2", features = [
 ], default-features = false }
 etcetera = "0.8.0"
 flate2 = "1.0.35"
-github-actions-models = { git = "https://github.com/woodruffw/github-actions-models", branch = "ww/uses" }
+github-actions-models = "0.19.0"
 http-cache-reqwest = "0.15.0"
 human-panic = "2.0.1"
 indexmap = "2.7.0"

--- a/src/audit/artipacked.rs
+++ b/src/audit/artipacked.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use anyhow::Result;
 use github_actions_models::{
-    common::{expr::ExplicitExpr, EnvValue},
+    common::{expr::ExplicitExpr, EnvValue, Uses},
     workflow::{job::StepBody, Job},
 };
 use itertools::Itertools;
@@ -10,6 +10,7 @@ use itertools::Itertools;
 use super::{audit_meta, Audit};
 use crate::{
     finding::{Confidence, Finding, Persona, Severity},
+    models::RepositoryUsesExt as _,
     state::AuditState,
 };
 use crate::{models::Workflow, utils::split_patterns};
@@ -64,11 +65,15 @@ impl Audit for Artipacked {
             let mut vulnerable_checkouts = vec![];
             let mut vulnerable_uploads = vec![];
             for step in job.steps() {
-                let StepBody::Uses { ref uses, ref with } = &step.deref().body else {
+                let StepBody::Uses {
+                    uses: Uses::Repository(ref uses),
+                    ref with,
+                } = &step.deref().body
+                else {
                     continue;
                 };
 
-                if uses.starts_with("actions/checkout") {
+                if uses.matches("actions/checkout") {
                     match with.get("persist-credentials") {
                         Some(EnvValue::Boolean(false)) => continue,
                         Some(EnvValue::Boolean(true)) => {
@@ -80,7 +85,7 @@ impl Audit for Artipacked {
                         // persist-credentials is true by default.
                         _ => vulnerable_checkouts.push((step, Persona::default())),
                     }
-                } else if uses.starts_with("actions/upload-artifact") {
+                } else if uses.matches("actions/upload-artifact") {
                     let Some(EnvValue::String(path)) = with.get("path") else {
                         continue;
                     };

--- a/src/audit/artipacked.rs
+++ b/src/audit/artipacked.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use super::{audit_meta, Audit};
 use crate::{
     finding::{Confidence, Finding, Persona, Severity},
-    models::RepositoryUsesExt as _,
+    models::uses::RepositoryUsesExt as _,
     state::AuditState,
 };
 use crate::{models::Workflow, utils::split_patterns};

--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -1,10 +1,12 @@
 use crate::audit::{audit_meta, Audit};
 use crate::finding::{Confidence, Finding, Severity};
 use crate::models::coordinate::{ActionCoordinate, Control, ControlFieldType, Toggle, Usage};
-use crate::models::{Job, Step, StepCommon, Steps, Uses};
+use crate::models::{Job, Step, StepCommon, Steps};
 use crate::state::AuditState;
+use github_actions_models::common::Uses;
 use github_actions_models::workflow::event::{BareEvent, BranchFilters, OptionalBody};
 use github_actions_models::workflow::Trigger;
+use std::str::FromStr;
 use std::sync::LazyLock;
 
 /// The list of know cache-aware actions
@@ -14,113 +16,113 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
     vec![
         // https://github.com/actions/cache/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("actions/cache").unwrap(),
+            uses: Uses::from_str("actions/cache").unwrap(),
             control: Control::new(Toggle::OptOut, "lookup-only", ControlFieldType::Boolean),
             enabled_by_default: true,
         },
         // https://github.com/actions/setup-java/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("actions/setup-java").unwrap(),
+            uses: Uses::from_str("actions/setup-java").unwrap(),
             control: Control::new(Toggle::OptIn, "cache", ControlFieldType::String),
             enabled_by_default: false,
         },
         // https://github.com/actions/setup-go/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("actions/setup-go").unwrap(),
+            uses: Uses::from_str("actions/setup-go").unwrap(),
             control: Control::new(Toggle::OptIn, "cache", ControlFieldType::Boolean),
             enabled_by_default: true,
         },
         // https://github.com/actions/setup-node/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("actions/setup-node").unwrap(),
+            uses: Uses::from_str("actions/setup-node").unwrap(),
             control: Control::new(Toggle::OptIn, "cache", ControlFieldType::String),
             enabled_by_default: false,
         },
         // https://github.com/actions/setup-python/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("actions/setup-python").unwrap(),
+            uses: Uses::from_str("actions/setup-python").unwrap(),
             control: Control::new(Toggle::OptIn, "cache", ControlFieldType::String),
             enabled_by_default: false,
         },
         // https://github.com/actions/setup-dotnet/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("actions/setup-dotnet").unwrap(),
+            uses: Uses::from_str("actions/setup-dotnet").unwrap(),
             control: Control::new(Toggle::OptIn, "cache", ControlFieldType::Boolean),
             enabled_by_default: false,
         },
         // https://github.com/astral-sh/setup-uv/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("astral-sh/setup-uv").unwrap(),
+            uses: Uses::from_str("astral-sh/setup-uv").unwrap(),
             control: Control::new(Toggle::OptOut, "enable-cache", ControlFieldType::String),
             enabled_by_default: true,
         },
         // https://github.com/Swatinem/rust-cache/blob/master/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("Swatinem/rust-cache").unwrap(),
+            uses: Uses::from_str("Swatinem/rust-cache").unwrap(),
             control: Control::new(Toggle::OptOut, "lookup-only", ControlFieldType::Boolean),
             enabled_by_default: true,
         },
         // https://github.com/ruby/setup-ruby/blob/master/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("ruby/setup-ruby").unwrap(),
+            uses: Uses::from_str("ruby/setup-ruby").unwrap(),
             control: Control::new(Toggle::OptIn, "bundler-cache", ControlFieldType::Boolean),
             enabled_by_default: false,
         },
         // https://github.com/PyO3/maturin-action/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("PyO3/maturin-action").unwrap(),
+            uses: Uses::from_str("PyO3/maturin-action").unwrap(),
             control: Control::new(Toggle::OptIn, "sccache", ControlFieldType::Boolean),
             enabled_by_default: false,
         },
         // https://github.com/mlugg/setup-zig/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("mlugg/setup-zig").unwrap(),
+            uses: Uses::from_str("mlugg/setup-zig").unwrap(),
             control: Control::new(Toggle::OptIn, "use-cache", ControlFieldType::Boolean),
             enabled_by_default: true,
         },
         // https://github.com/oven-sh/setup-bun/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("oven-sh/setup-bun").unwrap(),
+            uses: Uses::from_str("oven-sh/setup-bun").unwrap(),
             control: Control::new(Toggle::OptOut, "no-cache", ControlFieldType::Boolean),
             enabled_by_default: true,
         },
         // https://github.com/DeterminateSystems/magic-nix-cache-action/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("DeterminateSystems/magic-nix-cache-action").unwrap(),
+            uses: Uses::from_str("DeterminateSystems/magic-nix-cache-action").unwrap(),
             control: Control::new(Toggle::OptIn, "use-gha-cache", ControlFieldType::Boolean),
             enabled_by_default: true,
         },
         // https://github.com/graalvm/setup-graalvm/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("graalvm/setup-graalvm").unwrap(),
+            uses: Uses::from_str("graalvm/setup-graalvm").unwrap(),
             control: Control::new(Toggle::OptIn, "cache", ControlFieldType::String),
             enabled_by_default: false,
         },
         // https://github.com/gradle/actions/blob/main/setup-gradle/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("gradle/actions/setup-gradle").unwrap(),
+            uses: Uses::from_str("gradle/actions/setup-gradle").unwrap(),
             control: Control::new(Toggle::OptOut, "cache-disabled", ControlFieldType::Boolean),
             enabled_by_default: true,
         },
         // https://github.com/docker/setup-buildx-action/blob/master/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("docker/setup-buildx-action").unwrap(),
+            uses: Uses::from_str("docker/setup-buildx-action").unwrap(),
             control: Control::new(Toggle::OptIn, "cache-binary", ControlFieldType::Boolean),
             enabled_by_default: true,
         },
         // https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/action.yml
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("actions-rust-lang/setup-rust-toolchain").unwrap(),
+            uses: Uses::from_str("actions-rust-lang/setup-rust-toolchain").unwrap(),
             control: Control::new(Toggle::OptIn, "cache", ControlFieldType::Boolean),
             enabled_by_default: true,
         },
         // https://github.com/Mozilla-Actions/sccache-action/blob/main/action.yml
         ActionCoordinate::NotConfigurable(
-            Uses::from_step("Mozilla-Actions/sccache-action").unwrap(),
+            Uses::from_str("Mozilla-Actions/sccache-action").unwrap(),
         ),
         // https://github.com/nix-community/cache-nix-action/blob/main/action.yml
         ActionCoordinate::NotConfigurable(
-            Uses::from_step("nix-community/cache-nix-action").unwrap(),
+            Uses::from_str("nix-community/cache-nix-action").unwrap(),
         ),
     ]
 });
@@ -130,49 +132,49 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
 static KNOWN_PUBLISHER_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::new(|| {
     vec![
         // Public packages and/or binary distribution channels
-        ActionCoordinate::NotConfigurable(Uses::from_step("pypa/gh-action-pypi-publish").unwrap()),
-        ActionCoordinate::NotConfigurable(Uses::from_step("rubygems/release-gem").unwrap()),
-        ActionCoordinate::NotConfigurable(Uses::from_step("jreleaser/release-action").unwrap()),
-        ActionCoordinate::NotConfigurable(Uses::from_step("goreleaser/goreleaser-action").unwrap()),
+        ActionCoordinate::NotConfigurable(Uses::from_str("pypa/gh-action-pypi-publish").unwrap()),
+        ActionCoordinate::NotConfigurable(Uses::from_str("rubygems/release-gem").unwrap()),
+        ActionCoordinate::NotConfigurable(Uses::from_str("jreleaser/release-action").unwrap()),
+        ActionCoordinate::NotConfigurable(Uses::from_str("goreleaser/goreleaser-action").unwrap()),
         // Github releases
-        ActionCoordinate::NotConfigurable(Uses::from_step("softprops/action-gh-release").unwrap()),
+        ActionCoordinate::NotConfigurable(Uses::from_str("softprops/action-gh-release").unwrap()),
         ActionCoordinate::NotConfigurable(
-            Uses::from_step("release-drafter/release-drafter").unwrap(),
+            Uses::from_str("release-drafter/release-drafter").unwrap(),
         ),
         ActionCoordinate::NotConfigurable(
-            Uses::from_step("googleapis/release-please-action").unwrap(),
+            Uses::from_str("googleapis/release-please-action").unwrap(),
         ),
         // Container registries
         ActionCoordinate::Configurable {
-            uses: Uses::from_step("docker/build-push-action").unwrap(),
+            uses: Uses::from_str("docker/build-push-action").unwrap(),
             control: Control::new(Toggle::OptIn, "push", ControlFieldType::Boolean),
             enabled_by_default: true,
         },
         ActionCoordinate::NotConfigurable(
-            Uses::from_step("redhat-actions/push-to-registry").unwrap(),
+            Uses::from_str("redhat-actions/push-to-registry").unwrap(),
         ),
         // Cloud + Edge providers
         ActionCoordinate::NotConfigurable(
-            Uses::from_step("aws-actions/amazon-ecs-deploy-task-definition ").unwrap(),
+            Uses::from_str("aws-actions/amazon-ecs-deploy-task-definition ").unwrap(),
         ),
         ActionCoordinate::NotConfigurable(
-            Uses::from_step("aws-actions/aws-cloudformation-github-deploy").unwrap(),
+            Uses::from_str("aws-actions/aws-cloudformation-github-deploy").unwrap(),
         ),
-        ActionCoordinate::NotConfigurable(Uses::from_step("Azure/aci-deploy").unwrap()),
+        ActionCoordinate::NotConfigurable(Uses::from_str("Azure/aci-deploy").unwrap()),
         ActionCoordinate::NotConfigurable(
-            Uses::from_step("Azure/container-apps-deploy-action").unwrap(),
+            Uses::from_str("Azure/container-apps-deploy-action").unwrap(),
         ),
-        ActionCoordinate::NotConfigurable(Uses::from_step("Azure/functions-action").unwrap()),
-        ActionCoordinate::NotConfigurable(Uses::from_step("Azure/sql-action").unwrap()),
-        ActionCoordinate::NotConfigurable(Uses::from_step("cloudflare/wrangler-action").unwrap()),
+        ActionCoordinate::NotConfigurable(Uses::from_str("Azure/functions-action").unwrap()),
+        ActionCoordinate::NotConfigurable(Uses::from_str("Azure/sql-action").unwrap()),
+        ActionCoordinate::NotConfigurable(Uses::from_str("cloudflare/wrangler-action").unwrap()),
         ActionCoordinate::NotConfigurable(
-            Uses::from_step("google-github-actions/deploy-appengine").unwrap(),
-        ),
-        ActionCoordinate::NotConfigurable(
-            Uses::from_step("google-github-actions/deploy-cloudrun").unwrap(),
+            Uses::from_str("google-github-actions/deploy-appengine").unwrap(),
         ),
         ActionCoordinate::NotConfigurable(
-            Uses::from_step("google-github-actions/deploy-cloud-functions").unwrap(),
+            Uses::from_str("google-github-actions/deploy-cloudrun").unwrap(),
+        ),
+        ActionCoordinate::NotConfigurable(
+            Uses::from_str("google-github-actions/deploy-cloud-functions").unwrap(),
         ),
     ]
 });
@@ -240,7 +242,7 @@ impl CachePoisoning {
         ))
     }
 
-    fn evaluate_cache_usage(&self, step: &impl StepCommon) -> Option<Usage> {
+    fn evaluate_cache_usage<'s>(&self, step: &impl StepCommon<'s>) -> Option<Usage> {
         KNOWN_CACHE_AWARE_ACTIONS
             .iter()
             .find_map(|coord| coord.usage(step))

--- a/src/audit/impostor_commit.rs
+++ b/src/audit/impostor_commit.rs
@@ -6,13 +6,16 @@
 //! [`clank`]: https://github.com/chainguard-dev/clank
 
 use anyhow::{anyhow, Result};
-use github_actions_models::workflow::Job;
+use github_actions_models::{
+    common::{RepositoryUses, Uses},
+    workflow::Job,
+};
 
 use super::{audit_meta, Audit};
 use crate::{
     finding::{Confidence, Finding, Severity},
     github_api::{self, ComparisonStatus},
-    models::{RepositoryUses, Uses, Workflow},
+    models::{RepositoryUsesExt as _, Workflow},
     state::AuditState,
 };
 
@@ -31,14 +34,14 @@ audit_meta!(
 impl ImpostorCommit {
     fn named_ref_contains_commit(
         &self,
-        uses: &RepositoryUses<'_>,
+        uses: &RepositoryUses,
         base_ref: &str,
         head_ref: &str,
     ) -> Result<bool> {
         Ok(
             match self
                 .client
-                .compare_commits(uses.owner, uses.repo, base_ref, head_ref)?
+                .compare_commits(&uses.owner, &uses.repo, base_ref, head_ref)?
             {
                 // A base ref "contains" a commit if the base is either identical
                 // to the head ("identical") or the target is behind the base ("behind").
@@ -55,7 +58,7 @@ impl ImpostorCommit {
     /// Returns a boolean indicating whether or not this commit is an "impostor",
     /// i.e. resolves due to presence in GitHub's fork network but is not actually
     /// present in any of the specified `owner/repo`'s tags or branches.
-    fn impostor(&self, uses: RepositoryUses<'_>) -> Result<bool> {
+    fn impostor(&self, uses: &RepositoryUses) -> Result<bool> {
         // If there's no ref or the ref is not a commit, there's nothing to impersonate.
         let Some(head_ref) = uses.commit_ref() else {
             return Ok(false);
@@ -65,7 +68,7 @@ impl ImpostorCommit {
         // the branch or tag's history, so check those first.
         // Check tags before branches, since in practice version tags
         // are more commonly pinned.
-        let tags = self.client.list_tags(uses.owner, uses.repo)?;
+        let tags = self.client.list_tags(&uses.owner, &uses.repo)?;
 
         for tag in &tags {
             if tag.commit.sha == head_ref {
@@ -73,7 +76,7 @@ impl ImpostorCommit {
             }
         }
 
-        let branches = self.client.list_branches(uses.owner, uses.repo)?;
+        let branches = self.client.list_branches(&uses.owner, &uses.repo)?;
 
         for branch in &branches {
             if branch.commit.sha == head_ref {
@@ -152,7 +155,7 @@ impl Audit for ImpostorCommit {
                 Job::ReusableWorkflowCallJob(reusable) => {
                     // Reusable workflows can also be commit pinned, meaning
                     // they can also be impersonated.
-                    let Some(uses) = Uses::from_reusable(&reusable.uses) else {
+                    let Uses::Repository(uses) = &reusable.uses else {
                         continue;
                     };
 

--- a/src/audit/impostor_commit.rs
+++ b/src/audit/impostor_commit.rs
@@ -86,7 +86,7 @@ impl ImpostorCommit {
 
         for branch in &branches {
             if self.named_ref_contains_commit(
-                &uses,
+                uses,
                 &format!("refs/heads/{}", &branch.name),
                 head_ref,
             )? {
@@ -96,7 +96,7 @@ impl ImpostorCommit {
 
         for tag in &tags {
             if self.named_ref_contains_commit(
-                &uses,
+                uses,
                 &format!("refs/tags/{}", &tag.name),
                 head_ref,
             )? {

--- a/src/audit/impostor_commit.rs
+++ b/src/audit/impostor_commit.rs
@@ -15,7 +15,7 @@ use super::{audit_meta, Audit};
 use crate::{
     finding::{Confidence, Finding, Severity},
     github_api::{self, ComparisonStatus},
-    models::{RepositoryUsesExt as _, Workflow},
+    models::{uses::RepositoryUsesExt as _, Workflow},
     state::AuditState,
 };
 

--- a/src/audit/known_vulnerable_actions.rs
+++ b/src/audit/known_vulnerable_actions.rs
@@ -53,7 +53,7 @@ impl KnownVulnerableActions {
             Some(version) if !uses.ref_is_commit() => {
                 let Some(commit_ref) =
                     self.client
-                        .commit_for_ref(&uses.owner, &uses.repo, &version)?
+                        .commit_for_ref(&uses.owner, &uses.repo, version)?
                 else {
                     // No `ref -> commit` means that the action's version
                     // is probably just outright invalid.
@@ -78,7 +78,7 @@ impl KnownVulnerableActions {
             // which we should also probably support.
             Some(commit_ref) => match self
                 .client
-                .longest_tag_for_commit(&uses.owner, &uses.repo, &commit_ref)
+                .longest_tag_for_commit(&uses.owner, &uses.repo, commit_ref)
                 .with_context(|| {
                     format!(
                         "couldn't retrieve tag for {owner}/{repo}@{commit_ref}",
@@ -146,7 +146,7 @@ impl Audit for KnownVulnerableActions {
             return Ok(findings);
         };
 
-        for (severity, id) in self.action_known_vulnerabilities(&uses)? {
+        for (severity, id) in self.action_known_vulnerabilities(uses)? {
             findings.push(
                 Self::finding()
                     .confidence(Confidence::High)
@@ -172,7 +172,7 @@ impl Audit for KnownVulnerableActions {
             return Ok(findings);
         };
 
-        for (severity, id) in self.action_known_vulnerabilities(&uses)? {
+        for (severity, id) in self.action_known_vulnerabilities(uses)? {
             findings.push(
                 Self::finding()
                     .confidence(Confidence::High)

--- a/src/audit/known_vulnerable_actions.rs
+++ b/src/audit/known_vulnerable_actions.rs
@@ -14,7 +14,7 @@ use crate::models::CompositeStep;
 use crate::{
     finding::{Confidence, Severity},
     github_api,
-    models::RepositoryUsesExt,
+    models::uses::RepositoryUsesExt as _,
     state::AuditState,
 };
 

--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -80,7 +80,7 @@ impl Audit for RefConfusion {
                             continue;
                         };
 
-                        if self.confusable(&uses)? {
+                        if self.confusable(uses)? {
                             findings.push(
                                 Self::finding()
                                     .severity(Severity::Medium)
@@ -101,7 +101,7 @@ impl Audit for RefConfusion {
                         continue;
                     };
 
-                    if self.confusable(&uses)? {
+                    if self.confusable(uses)? {
                         findings.push(
                             Self::finding()
                                 .severity(Severity::Medium)
@@ -126,7 +126,7 @@ impl Audit for RefConfusion {
             return Ok(findings);
         };
 
-        if self.confusable(&uses)? {
+        if self.confusable(uses)? {
             findings.push(
                 Self::finding()
                     .severity(Severity::Medium)

--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -9,6 +9,7 @@
 use std::ops::Deref;
 
 use anyhow::{anyhow, Result};
+use github_actions_models::common::{RepositoryUses, Uses};
 use github_actions_models::workflow::Job;
 
 use super::{audit_meta, Audit};
@@ -17,7 +18,7 @@ use crate::models::CompositeStep;
 use crate::{
     finding::{Confidence, Severity},
     github_api,
-    models::{RepositoryUses, Uses},
+    models::RepositoryUsesExt,
     state::AuditState,
 };
 
@@ -40,8 +41,8 @@ impl RefConfusion {
             return Ok(false);
         };
 
-        let branches_match = self.client.has_branch(uses.owner, uses.repo, sym_ref)?;
-        let tags_match = self.client.has_tag(uses.owner, uses.repo, sym_ref)?;
+        let branches_match = self.client.has_branch(&uses.owner, &uses.repo, sym_ref)?;
+        let tags_match = self.client.has_tag(&uses.owner, &uses.repo, sym_ref)?;
 
         // If both the branch and tag namespaces have a match, we have a
         // confusable ref.
@@ -96,7 +97,7 @@ impl Audit for RefConfusion {
                     }
                 }
                 Job::ReusableWorkflowCallJob(reusable) => {
-                    let Some(uses) = Uses::from_reusable(&reusable.uses) else {
+                    let Uses::Repository(uses) = &reusable.uses else {
                         continue;
                     };
 

--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -18,7 +18,7 @@ use crate::models::CompositeStep;
 use crate::{
     finding::{Confidence, Severity},
     github_api,
-    models::RepositoryUsesExt,
+    models::uses::RepositoryUsesExt as _,
     state::AuditState,
 };
 

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -17,7 +17,7 @@ use github_actions_models::{action, common::expr::LoE, workflow::job, workflow::
 use super::{audit_meta, Audit};
 use crate::{
     expr::{BinOp, Expr, UnOp},
-    finding::{Confidence, Persona, Severity},
+    finding::{Confidence, Persona, Severity, SymbolicLocation},
     models::{self, StepCommon},
     state::AuditState,
     utils::extract_expressions,
@@ -79,6 +79,16 @@ const SAFE_CONTEXTS: &[&str] = &[
 ];
 
 impl TemplateInjection {
+    fn script_with_location<'s>(
+        step: &'s impl StepCommon,
+    ) -> Option<(&'s str, SymbolicLocation<'s>)> {
+        let (Some(uses), Some(with)) = (step.uses(), step.with()) else {
+            return None;
+        };
+
+        todo!()
+    }
+
     /// Checks whether an expression is "safe" for the purposes of template
     /// injection.
     ///

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -19,7 +19,7 @@ use super::{audit_meta, Audit};
 use crate::{
     expr::{BinOp, Expr, UnOp},
     finding::{Confidence, Persona, Severity, SymbolicLocation},
-    models::{self, RepositoryUsesExt, StepCommon},
+    models::{self, uses::RepositoryUsesExt as _, StepCommon},
     state::AuditState,
     utils::extract_expressions,
 };

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -43,7 +43,7 @@ impl Audit for UnpinnedUses {
             return Ok(vec![]);
         };
 
-        let Some((annotation, severity, persona)) = self.evaluate_pinning(&uses) else {
+        let Some((annotation, severity, persona)) = self.evaluate_pinning(uses) else {
             return Ok(vec![]);
         };
 
@@ -74,7 +74,7 @@ impl Audit for UnpinnedUses {
             return Ok(vec![]);
         };
 
-        let Some((annotation, severity, persona)) = self.evaluate_pinning(&uses) else {
+        let Some((annotation, severity, persona)) = self.evaluate_pinning(uses) else {
             return Ok(vec![]);
         };
 

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -1,6 +1,8 @@
+use github_actions_models::common::Uses;
+
 use super::{audit_meta, Audit, AuditState, Finding, Step};
 use crate::finding::{Confidence, Persona, Severity};
-use crate::models::{CompositeStep, Uses};
+use crate::models::{CompositeStep, UsesExt as _};
 
 pub(crate) struct UnpinnedUses;
 

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -2,7 +2,7 @@ use github_actions_models::common::Uses;
 
 use super::{audit_meta, Audit, AuditState, Finding, Step};
 use crate::finding::{Confidence, Persona, Severity};
-use crate::models::{CompositeStep, UsesExt as _};
+use crate::models::{uses::UsesExt as _, CompositeStep};
 
 pub(crate) struct UnpinnedUses;
 

--- a/src/audit/use_trusted_publishing.rs
+++ b/src/audit/use_trusted_publishing.rs
@@ -1,13 +1,16 @@
 use std::ops::Deref;
 
 use anyhow::Ok;
-use github_actions_models::{common::EnvValue, workflow::job::StepBody};
+use github_actions_models::{
+    common::{EnvValue, Uses},
+    workflow::job::StepBody,
+};
 use indexmap::IndexMap;
 
 use super::{audit_meta, Audit};
 use crate::{
     finding::{Confidence, Severity},
-    models::Uses,
+    models::RepositoryUsesExt as _,
     state::AuditState,
 };
 
@@ -74,11 +77,11 @@ impl Audit for UseTrustedPublishing {
     fn audit_step<'w>(&self, step: &super::Step<'w>) -> anyhow::Result<Vec<super::Finding<'w>>> {
         let mut findings = vec![];
 
-        let StepBody::Uses { uses, with } = &step.deref().body else {
-            return Ok(findings);
-        };
-
-        let Some(Uses::Repository(uses)) = Uses::from_step(uses) else {
+        let StepBody::Uses {
+            uses: Uses::Repository(uses),
+            with,
+        } = &step.deref().body
+        else {
             return Ok(findings);
         };
 

--- a/src/audit/use_trusted_publishing.rs
+++ b/src/audit/use_trusted_publishing.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 use super::{audit_meta, Audit};
 use crate::{
     finding::{Confidence, Severity},
-    models::RepositoryUsesExt as _,
+    models::uses::RepositoryUsesExt as _,
     state::AuditState,
 };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::{io::stdout, process::ExitCode};
+use std::{io::stdout, process::ExitCode, str::FromStr};
 
 use annotate_snippets::{Level, Renderer};
 use anstream::{eprintln, stream::IsTerminal};
@@ -9,9 +9,10 @@ use clap::{Parser, ValueEnum};
 use clap_verbosity_flag::InfoLevel;
 use config::Config;
 use finding::{Confidence, Persona, Severity};
+use github_actions_models::common::Uses;
 use github_api::GitHubHost;
 use indicatif::ProgressStyle;
-use models::{Action, Uses};
+use models::Action;
 use owo_colors::OwoColorize;
 use registry::{AuditRegistry, FindingRegistry, InputRegistry};
 use state::AuditState;
@@ -217,7 +218,7 @@ fn collect_from_repo_slug(
     registry: &mut InputRegistry,
 ) -> Result<()> {
     // Our pre-existing `uses: <slug>` parser does 90% of the work for us.
-    let Some(Uses::Repository(slug)) = Uses::from_step(input) else {
+    let Ok(Uses::Repository(slug)) = Uses::from_str(input) else {
         return Err(anyhow!(tip(
             format!("invalid input: {input}"),
             format!(

--- a/src/models/coordinate.rs
+++ b/src/models/coordinate.rs
@@ -15,7 +15,8 @@
 
 use github_actions_models::common::{expr::ExplicitExpr, EnvValue, Uses};
 
-use super::{RepositoryUsesExt as _, StepBodyCommon, StepCommon};
+use super::{StepBodyCommon, StepCommon};
+use crate::models::uses::RepositoryUsesExt as _;
 
 pub(crate) enum ActionCoordinate {
     Configurable {

--- a/src/models/uses.rs
+++ b/src/models/uses.rs
@@ -1,0 +1,102 @@
+//! Extension traits for the `Uses` APIs.
+
+use github_actions_models::common::{RepositoryUses, Uses};
+
+/// Useful APIs for interacting with `uses: org/repo` clauses.
+pub(crate) trait RepositoryUsesExt {
+    /// Returns whether this `uses:` clause "matches" the given template.
+    /// The template is itself formatted like a normal `uses:` clause.
+    ///
+    /// This is an asymmetrical match: `actions/checkout@v3` "matches"
+    /// the `actions/checkout` template but not vice versa.
+    ///
+    /// Comparisons are case-insensitive, since GitHub's own APIs are insensitive.
+    fn matches(&self, template: &str) -> bool;
+
+    /// Like [`RepositoryUsesExt::matches`].
+    fn matches_uses(&self, template: &RepositoryUses) -> bool;
+
+    /// Returns whether this `uses:` clause has a `git` ref and, if so,
+    /// whether that ref is a commit ref.
+    ///
+    /// For example, `foo/bar@baz` returns false while `foo/bar@1234...`
+    /// returns true.
+    fn ref_is_commit(&self) -> bool;
+
+    /// Returns the `git` ref for this `uses:`, if present.
+    fn commit_ref(&self) -> Option<&str>;
+
+    /// Returns the *symbolic* `git` ref for this `uses`, if present.
+    ///
+    /// Commit refs (i.e. SHA refs) are not returned.
+    fn symbolic_ref(&self) -> Option<&str>;
+}
+
+impl RepositoryUsesExt for RepositoryUses {
+    fn matches(&self, template: &str) -> bool {
+        let Ok(other) = template.parse::<RepositoryUses>() else {
+            return false;
+        };
+
+        self.matches_uses(&other)
+    }
+
+    fn matches_uses(&self, template: &RepositoryUses) -> bool {
+        self.owner.eq_ignore_ascii_case(&template.owner)
+            && self.repo.eq_ignore_ascii_case(&template.repo)
+            && self.subpath.as_ref().map(|s| s.to_lowercase())
+                == template.subpath.as_ref().map(|s| s.to_lowercase())
+            && template.git_ref.as_ref().map_or(true, |git_ref| {
+                Some(git_ref.to_lowercase()) == self.git_ref.as_ref().map(|r| r.to_lowercase())
+            })
+    }
+
+    fn ref_is_commit(&self) -> bool {
+        match &self.git_ref {
+            Some(git_ref) => git_ref.len() == 40 && git_ref.chars().all(|c| c.is_ascii_hexdigit()),
+            None => false,
+        }
+    }
+
+    fn commit_ref(&self) -> Option<&str> {
+        match &self.git_ref {
+            Some(git_ref) if self.ref_is_commit() => Some(git_ref),
+            _ => None,
+        }
+    }
+
+    fn symbolic_ref(&self) -> Option<&str> {
+        match &self.git_ref {
+            Some(git_ref) if !self.ref_is_commit() => Some(git_ref),
+            _ => None,
+        }
+    }
+}
+
+/// Useful APIs for interacting with all kinds of `uses:` clauses.
+pub(crate) trait UsesExt {
+    fn unpinned(&self) -> bool;
+    fn unhashed(&self) -> bool;
+}
+
+impl UsesExt for Uses {
+    /// Whether the `uses:` is unpinned.
+    fn unpinned(&self) -> bool {
+        match self {
+            Uses::Docker(docker) => docker.hash.is_none() && docker.tag.is_none(),
+            Uses::Repository(repo) => repo.git_ref.is_none(),
+            Uses::Local(local) => local.git_ref.is_none(),
+        }
+    }
+
+    /// Whether the `uses:` is unhashed (but potentially pinned with a non-hash),
+    fn unhashed(&self) -> bool {
+        match self {
+            // TODO: Handle this case. Right now it's not very important,
+            // since we don't really analyze local action uses at all.
+            Uses::Local(_) => false,
+            Uses::Repository(repo) => !repo.ref_is_commit(),
+            Uses::Docker(docker) => docker.hash.is_none(),
+        }
+    }
+}

--- a/src/models/uses.rs
+++ b/src/models/uses.rs
@@ -93,7 +93,9 @@ impl UsesExt for Uses {
     fn unhashed(&self) -> bool {
         match self {
             // TODO: Handle this case. Right now it's not very important,
-            // since we don't really analyze local action uses at all.
+            // since we don't really analyze local action uses at all,
+            // and the "hashedness" of a local action is mostly moot anyways
+            // (since it's fully contained within the calling repo),
             Uses::Local(_) => false,
             Uses::Repository(repo) => !repo.ref_is_commit(),
             Uses::Docker(docker) => docker.hash.is_none(),

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -279,6 +279,12 @@ fn template_injection() -> Result<()> {
         ))
         .run()?);
 
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "template-injection/pr-425-backstop/action.yml"
+        ))
+        .run()?);
+
     Ok(())
 }
 

--- a/tests/snapshots/snapshot__template_injection-8.snap
+++ b/tests/snapshots/snapshot__template_injection-8.snap
@@ -1,0 +1,62 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"template-injection/pr-425-backstop/action.yml\")).run()?"
+snapshot_kind: text
+---
+error[template-injection]: code injection via template expansion
+  --> @@INPUT@@:12:7
+   |
+12 |       - name: case1
+   |         ^^^^^^^^^^^ this step
+13 | /       run: |
+14 | |         hello ${{ inputs.expandme }}
+   | |____________________________________^ inputs.expandme may expand into attacker-controllable code
+   |
+   = note: audit confidence → Low
+
+error[template-injection]: code injection via template expansion
+  --> @@INPUT@@:17:7
+   |
+17 |     - name: case2
+   |       ^^^^^^^^^^^ this step
+18 |       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+19 |       with:
+20 |         script: return "${{ inputs.expandme }}"
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inputs.expandme may expand into attacker-controllable code
+   |
+   = note: audit confidence → Low
+
+error[template-injection]: code injection via template expansion
+  --> @@INPUT@@:22:7
+   |
+22 |       - name: case3
+   |         ^^^^^^^^^^^ this step
+23 |         uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd
+24 |         with:
+25 | /         inlineScript: |
+26 | |           echo "hello ${{ inputs.expandme }}"
+   | |_____________________________________________^ inputs.expandme may expand into attacker-controllable code
+   |
+   = note: audit confidence → Low
+
+error[template-injection]: code injection via template expansion
+  --> @@INPUT@@:28:7
+   |
+28 |     - name: case4
+   |       ^^^^^^^^^^^ this step
+29 |       uses: azure/powershell
+30 |       with:
+31 |         inlineScript: Get-AzVM -ResourceGroupName "${{ inputs.expandme }}"
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ inputs.expandme may expand into attacker-controllable code
+   |
+   = note: audit confidence → Low
+
+warning[unpinned-uses]: unpinned action reference
+  --> @@INPUT@@:29:7
+   |
+29 |       uses: azure/powershell
+   |       ---------------------- action is not pinned to a tag, branch, or hash ref
+   |
+   = note: audit confidence → High
+
+5 findings: 0 unknown, 0 informational, 0 low, 1 medium, 4 high

--- a/tests/test-data/template-injection/pr-425-backstop/action.yml
+++ b/tests/test-data/template-injection/pr-425-backstop/action.yml
@@ -1,0 +1,31 @@
+name: pr-425-backstop
+description: Functional test for changes in PR#425
+
+inputs:
+  expandme:
+    required: true
+    description: expand me
+
+runs:
+  using: composite
+  steps:
+    - name: case1
+      run: |
+        hello ${{ inputs.expandme }}
+      shell: bash
+
+    - name: case2
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+      with:
+        script: return "${{ inputs.expandme }}"
+
+    - name: case3
+      uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd
+      with:
+        inlineScript: |
+          echo "hello ${{ inputs.expandme }}"
+
+    - name: case4
+      uses: azure/powershell
+      with:
+        inlineScript: Get-AzVM -ResourceGroupName "${{ inputs.expandme }}"


### PR DESCRIPTION
~~WIP.~~

This will allow me to remove the `uses()` and `with()` trait methods, which encode unnecessary runtime error states.

More fully, this implies that the `Uses` model needs to be pushed into `github_actions_models` and made into a hard parsing invariant (i.e. we should fail to parse if a `uses:` clause is invalid).

xref https://github.com/woodruffw/github-actions-models/pull/29