### PR TITLE
fix: bump github-actions-models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "github-actions-models"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9576dac15088d565d47b67d09bd9fd9f0d84bda4b0d34af91ab55327f4c2d0"
+checksum = "1d63182827fb1d242303a2365a963579469c66559011fa01c4b5822a19be8075"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap-verbosity-flag = { version = "3.0.2", features = [
 ], default-features = false }
 etcetera = "0.8.0"
 flate2 = "1.0.35"
-github-actions-models = "0.19.0"
+github-actions-models = "0.20.0"
 http-cache-reqwest = "0.15.0"
 human-panic = "2.0.1"
 indexmap = "2.7.0"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,9 +7,12 @@ description: Abbreviated change notes about each zizmor release.
 This page contains _abbreviated_, user-focused release notes for each version
 of `zizmor`.
 
-## Upcoming (UNRELEASED)
+## v1.1.1 (UNRELEASED)
 
-Nothing to see here (yet!)
+### Fixed
+
+* Fixed a regression where workflows with calls to unpinned reusable workflows
+  would fail to parse
 
 ## v1.1.0
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,7 +12,7 @@ of `zizmor`.
 ### Fixed
 
 * Fixed a regression where workflows with calls to unpinned reusable workflows
-  would fail to parse
+  would fail to parse (#437)
 
 ## v1.1.0
 


### PR DESCRIPTION
Fixes #431.

See https://github.com/woodruffw/github-actions-models/pull/30 for full fix contents.