### PR TITLE
refactor: make excessive-permissions more correct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
 
 name: release
 
+permissions: {}
+
 jobs:
   crates:
     runs-on: ubuntu-latest

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -139,6 +139,11 @@ Users frequently over-scope their workflow and job permissions,
 or set broad workflow-level permissions without realizing that
 all jobs inherit those permissions.
 
+Furthermore, users often don't realize that the
+[*default* `GITHUB_TOKEN` permissions can be very broad](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token),
+meaning that workflows that don't configure any permissions at all can *still*
+provide excessive credentials to their individual jobs.
+
 ### Remediation
 
 In general, permissions should be declared as minimally as possible, and

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,8 @@ of `zizmor`.
 
 * The [unpinned-uses] audit no longer flags local reusable workflows or actions
   as unpinned/unhashed (#439)
+* The [excessive-permissions] audit has been refactored, and better captures
+  both true positive and true negative cases (#441)
 
 ## v1.1.1
 

--- a/src/audit/excessive_permissions.rs
+++ b/src/audit/excessive_permissions.rs
@@ -7,7 +7,7 @@ use github_actions_models::{
 
 use super::{audit_meta, Audit};
 use crate::{
-    finding::{Confidence, Persona, Severity},
+    finding::{Confidence, Persona, Severity, SymbolicLocation},
     AuditState,
 };
 
@@ -36,7 +36,7 @@ static KNOWN_PERMISSIONS: LazyLock<HashMap<&str, Severity>> = LazyLock::new(|| {
 audit_meta!(
     ExcessivePermissions,
     "excessive-permissions",
-    "overly broad workflow or job-level permissions"
+    "overly broad permissions"
 );
 
 pub(crate) struct ExcessivePermissions {
@@ -67,22 +67,82 @@ impl Audit for ExcessivePermissions {
             Persona::Regular
         };
 
-        // Top-level permissions.
-        for (severity, confidence, note) in self.check_permissions(&workflow.permissions, None) {
-            findings.push(
-                Self::finding()
-                    .severity(severity)
-                    .confidence(confidence)
-                    .persona(persona)
-                    .add_location(
-                        workflow
-                            .location()
-                            .primary()
-                            .with_keys(&["permissions".into()])
-                            .annotated(note),
-                    )
-                    .build(workflow)?,
-            )
+        // Handle top-level permissions.
+        let location = workflow.location().primary();
+        let explicit_parent_permissions = !matches!(
+            &workflow.permissions,
+            Permissions::Base(BasePermission::Default)
+        );
+        match &workflow.permissions {
+            Permissions::Base(base) => match base {
+                BasePermission::Default => findings.push(
+                    Self::finding()
+                        .severity(Severity::Medium)
+                        .confidence(Confidence::Medium)
+                        .persona(persona)
+                        .add_location(
+                            location
+                                .primary()
+                                .annotated("default permissions used due to no permissions: block"),
+                        )
+                        .build(workflow)?,
+                ),
+                BasePermission::ReadAll => findings.push(
+                    Self::finding()
+                        .severity(Severity::Medium)
+                        .confidence(Confidence::High)
+                        .persona(persona)
+                        .add_location(
+                            location
+                                .primary()
+                                .with_keys(&["permissions".into()])
+                                .annotated("uses read-all permissions"),
+                        )
+                        .build(workflow)?,
+                ),
+                BasePermission::WriteAll => findings.push(
+                    Self::finding()
+                        .severity(Severity::High)
+                        .confidence(Confidence::High)
+                        .persona(persona)
+                        .add_location(
+                            location
+                                .primary()
+                                .with_keys(&["permissions".into()])
+                                .annotated("uses write-all permissions"),
+                        )
+                        .build(workflow)?,
+                ),
+            },
+            Permissions::Explicit(perms) => {
+                for (name, perm) in perms {
+                    if *perm != Permission::Write {
+                        continue;
+                    }
+
+                    let severity = KNOWN_PERMISSIONS.get(name.as_str()).unwrap_or_else(|| {
+                        tracing::warn!("unknown permission: {name}");
+
+                        &Severity::Unknown
+                    });
+
+                    findings.push(
+                        Self::finding()
+                            .severity(*severity)
+                            .confidence(Confidence::High)
+                            .persona(persona)
+                            .add_location(
+                                location
+                                    .with_keys(&["permissions".into(), name.as_str().into()])
+                                    .primary()
+                                    .annotated(format!(
+                                        "{name}: write is overly broad at the workflow level"
+                                    )),
+                            )
+                            .build(workflow)?,
+                    );
+                }
+            }
         }
 
         for job in workflow.jobs() {
@@ -90,19 +150,18 @@ impl Audit for ExcessivePermissions {
                 continue;
             };
 
-            for (severity, confidence, note) in
-                self.check_permissions(&normal.permissions, Some(&workflow.permissions))
-            {
+            let job_location = job.location();
+            if let Some((severity, confidence, perm_location)) = self.check_job_permissions(
+                &normal.permissions,
+                explicit_parent_permissions,
+                job_location.clone(),
+            ) {
                 findings.push(
                     Self::finding()
                         .severity(severity)
                         .confidence(confidence)
-                        .add_location(
-                            job.location()
-                                .primary()
-                                .with_keys(&["permissions".into()])
-                                .annotated(note),
-                        )
+                        .add_location(job_location)
+                        .add_location(perm_location.primary())
                         .build(workflow)?,
                 )
             }
@@ -113,64 +172,43 @@ impl Audit for ExcessivePermissions {
 }
 
 impl ExcessivePermissions {
-    fn check_permissions(
+    fn check_job_permissions<'a>(
         &self,
         permissions: &Permissions,
-        parent: Option<&Permissions>,
-    ) -> Vec<(Severity, Confidence, String)> {
+        explicit_parent_permissions: bool,
+        location: SymbolicLocation<'a>,
+    ) -> Option<(Severity, Confidence, SymbolicLocation<'a>)> {
         match permissions {
             Permissions::Base(base) => match base {
-                // TODO: Think more about what to do here. Flagging default
-                // permissions is likely to be noisy and is annoying to do,
-                // since it involves the *absence* of a key in the YAML
-                // rather than its presence.
-                BasePermission::Default => vec![],
-                BasePermission::ReadAll => vec![(
+                // The job has no explicit permissions, meaning it gets
+                // the default $GITHUB_TOKEN *if* the workflow doesn't
+                // set any permissions.
+                BasePermission::Default if !explicit_parent_permissions => Some((
+                    Severity::Medium,
+                    Confidence::Medium,
+                    location.annotated("default permissions used due to no permissions: block"),
+                )),
+                BasePermission::Default => None,
+                BasePermission::ReadAll => Some((
                     Severity::Medium,
                     Confidence::High,
-                    "uses read-all permissions".into(),
-                )],
-                BasePermission::WriteAll => vec![(
+                    location
+                        .with_keys(&["permissions".into()])
+                        .annotated("uses read-all permissions"),
+                )),
+                BasePermission::WriteAll => Some((
                     Severity::High,
                     Confidence::High,
-                    "uses write-all permissions".into(),
-                )],
+                    location
+                        .with_keys(&["permissions".into()])
+                        .annotated("uses write-all permissions"),
+                )),
             },
-            Permissions::Explicit(perms) => match parent {
-                // In the general case, it's impossible to tell whether a
-                // job-level permission block is over-scoped.
-                Some(_) => vec![],
-                // Top-level permission-blocks should almost never contain
-                // write permissions.
-                None => {
-                    let mut results = vec![];
-
-                    for (name, perm) in perms {
-                        if *perm != Permission::Write {
-                            continue;
-                        }
-
-                        match KNOWN_PERMISSIONS.get(name.as_str()) {
-                            Some(sev) => results.push((
-                                *sev,
-                                Confidence::High,
-                                format!("{name}: write is overly broad at the workflow level"),
-                            )),
-                            None => {
-                                tracing::debug!("unknown permission: {name}");
-
-                                results.push((
-                                    Severity::Unknown,
-                                    Confidence::High,
-                                    format!("{name}: write is overly broad at the workflow level"),
-                                ))
-                            }
-                        }
-                    }
-
-                    results
-                }
-            },
+            // In the general case, it's impossible to tell whether a job-level
+            // permission block is over-scoped.
+            // TODO: We could in theory refine this by collecting minimum permission
+            // sets for common actions, but that might be overkill.
+            Permissions::Explicit(_) => None,
         }
     }
 }

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -389,6 +389,36 @@ fn excessive_permissions() -> Result<()> {
         .args(["--pedantic"])
         .run()?);
 
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-default-perms.yml"
+        ))
+        .args(["--pedantic"])
+        .run()?);
+
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-read-all.yml"
+        ))
+        .run()?);
+
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-write-all.yml"
+        ))
+        .run()?);
+
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-empty-perms.yml"
+        ))
+        .run()?);
+
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/jobs-broaden-permissions.yml"
+        ))
+        .run()?);
     Ok(())
 }
 

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -425,6 +425,12 @@ fn excessive_permissions() -> Result<()> {
             "excessive-permissions/workflow-write-explicit.yml"
         ))
         .run()?);
+
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-default-perms-all-jobs-explicit.yml"
+        ))
+        .run()?);
     Ok(())
 }
 

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -419,6 +419,12 @@ fn excessive_permissions() -> Result<()> {
             "excessive-permissions/jobs-broaden-permissions.yml"
         ))
         .run()?);
+
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-write-explicit.yml"
+        ))
+        .run()?);
     Ok(())
 }
 

--- a/tests/snapshots/snapshot__artipacked-2.snap
+++ b/tests/snapshots/snapshot__artipacked-2.snap
@@ -4,9 +4,9 @@ expression: "zizmor().workflow(workflow_under_test(\"artipacked.yml\")).run()?"
 snapshot_kind: text
 ---
 warning[artipacked]: credential persistence through GitHub Actions artifacts
-  --> @@INPUT@@:13:9
+  --> @@INPUT@@:15:9
    |
-13 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+15 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
    |         ---------------------------------------------------------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__artipacked-3.snap
+++ b/tests/snapshots/snapshot__artipacked-3.snap
@@ -4,20 +4,20 @@ expression: "zizmor().workflow(workflow_under_test(\"artipacked.yml\")).args([\"
 snapshot_kind: text
 ---
 warning[artipacked]: credential persistence through GitHub Actions artifacts
-  --> @@INPUT@@:13:9
+  --> @@INPUT@@:15:9
    |
-13 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+15 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
    |         ---------------------------------------------------------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low
 
 warning[artipacked]: credential persistence through GitHub Actions artifacts
-  --> @@INPUT@@:18:9
+  --> @@INPUT@@:20:9
    |
-18 |         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+20 |         - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
    |  _________-
-19 | |         with:
-20 | |           persist-credentials: true
+21 | |         with:
+22 | |           persist-credentials: true
    | |____________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__artipacked.snap
+++ b/tests/snapshots/snapshot__artipacked.snap
@@ -4,9 +4,9 @@ expression: "zizmor().workflow(workflow_under_test(\"artipacked.yml\")).args([\"
 snapshot_kind: text
 ---
 warning[artipacked]: credential persistence through GitHub Actions artifacts
-  --> @@INPUT@@:13:9
+  --> @@INPUT@@:15:9
    |
-13 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
+15 |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
    |         ---------------------------------------------------------------------------- does not set persist-credentials: false
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__cache_poisoning-10.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-10.snap
@@ -4,14 +4,14 @@ expression: "zizmor().workflow(workflow_under_test(\"cache-poisoning/publisher-s
 snapshot_kind: text
 ---
 error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
-  --> @@INPUT@@:23:9
+  --> @@INPUT@@:25:9
    |
-16 |         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+18 |         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
-17 |
+19 |
 ...
-22 |       - name: Publish draft release on Github
-23 |         uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
+24 |       - name: Publish draft release on Github
+25 |         uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ runtime artifacts usually published here
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__cache_poisoning-11.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-11.snap
@@ -13,8 +13,8 @@ error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache pois
    | |________________^ generally used when publishing artifacts generated at runtime
  9 |
 ...
-24 |         - name: true-positive-2
-25 |           uses: actions/setup-go@v5
+26 |         - name: true-positive-2
+27 |           uses: actions/setup-go@v5
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
    |
    = note: audit confidence → Low
@@ -29,12 +29,12 @@ error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache pois
    | |________________^ generally used when publishing artifacts generated at runtime
  9 |
 ...
-31 |           uses: actions/setup-go@v5
-32 | /         with:
-33 | |           go-version: stable
-34 | |           cache: true
-35 | |
-36 | |       # Finding because setup enables cache explicitly
+33 |           uses: actions/setup-go@v5
+34 | /         with:
+35 | |           go-version: stable
+36 | |           cache: true
+37 | |
+38 | |       # Finding because setup enables cache explicitly
    | |______________________________________________________^ opt-in for caching here
    |
    = note: audit confidence → Low
@@ -49,10 +49,10 @@ error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache pois
    | |________________^ generally used when publishing artifacts generated at runtime
  9 |
 ...
-38 |           uses: actions/setup-go@v5
-39 | /         with:
-40 | |           go-version: stable
-41 | |           cache: "true"
+40 |           uses: actions/setup-go@v5
+41 | /         with:
+42 | |           go-version: stable
+43 | |           cache: "true"
    | |________________________^ opt-in for caching here
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__cache_poisoning-12.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-12.snap
@@ -9,12 +9,12 @@ error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache pois
  1 | / on:
  2 | |   push:
  3 | |     tags:
- 4 | |       - '**'
+ 4 | |       - "**"
    | |____________^ generally used when publishing artifacts generated at runtime
  5 |
 ...
-15 |         - name: Setup CI caching
-16 |           uses: Mozilla-Actions/sccache-action@054db53350805f83040bf3e6e9b8cf5a139aa7c9
+17 |         - name: Setup CI caching
+18 |           uses: Mozilla-Actions/sccache-action@054db53350805f83040bf3e6e9b8cf5a139aa7c9
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ caching always restored here
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__cache_poisoning-13.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-13.snap
@@ -9,12 +9,12 @@ error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache pois
  1 | / on:
  2 | |   push:
  3 | |     branches:
- 4 | |       - 'release-v2.0.0'
+ 4 | |       - "release-v2.0.0"
    | |________________________^ generally used when publishing artifacts generated at runtime
  5 |
 ...
-15 |         - name: Setup CI caching
-16 |           uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+17 |         - name: Setup CI caching
+18 |           uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__cache_poisoning-2.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-2.snap
@@ -6,14 +6,13 @@ snapshot_kind: text
 error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> @@INPUT@@:1:1
    |
- 1 | / on:
- 2 | |   release
-   | |_________^ generally used when publishing artifacts generated at runtime
- 3 |
+ 1 | on: release
+   | ^^^^^^^^^^^ generally used when publishing artifacts generated at runtime
+ 2 |
 ...
-14 |         - name: Setup CI caching
-15 |           uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
-   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
+15 |       - name: Setup CI caching
+16 |         uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
    |
    = note: audit confidence → Low
 

--- a/tests/snapshots/snapshot__cache_poisoning-3.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-3.snap
@@ -6,15 +6,14 @@ snapshot_kind: text
 error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> @@INPUT@@:1:1
    |
- 1 | / on:
- 2 | |   release
-   | |_________^ generally used when publishing artifacts generated at runtime
- 3 |
+ 1 |   on: release
+   |   ^^^^^^^^^^^ generally used when publishing artifacts generated at runtime
+ 2 |
 ...
-14 |           uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
-15 | /         with:
-16 | |           dotnet-version: '5.0.x'
-17 | |           cache: true
+15 |           uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
+16 | /         with:
+17 | |           dotnet-version: "5.0.x"
+18 | |           cache: true
    | |_____________________^ opt-in for caching here
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__cache_poisoning-4.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-4.snap
@@ -6,15 +6,14 @@ snapshot_kind: text
 error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> @@INPUT@@:1:1
    |
- 1 | / on:
- 2 | |   release
-   | |_________^ generally used when publishing artifacts generated at runtime
- 3 |
+ 1 |   on: release
+   |   ^^^^^^^^^^^ generally used when publishing artifacts generated at runtime
+ 2 |
 ...
-14 |           uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
-15 | /         with:
-16 | |           python-version: "3.12"
-17 | |           enable-cache: ${{ github.ref == 'refs/heads/main' }}
+15 |           uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a
+16 | /         with:
+17 | |           python-version: "3.12"
+18 | |           enable-cache: ${{ github.ref == 'refs/heads/main' }}
    | |______________________________________________________________^ opt-in for caching might happen here
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__cache_poisoning-5.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-5.snap
@@ -6,16 +6,15 @@ snapshot_kind: text
 error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> @@INPUT@@:1:1
    |
- 1 | / on:
- 2 | |   release
-   | |_________^ generally used when publishing artifacts generated at runtime
- 3 |
+ 1 |   on: release
+   |   ^^^^^^^^^^^ generally used when publishing artifacts generated at runtime
+ 2 |
 ...
-14 |           uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
-15 | /         with:
-16 | |           distribution: 'zulu'
-17 | |           cache: 'gradle'
-18 | |           java-version: '17'
+15 |           uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
+16 | /         with:
+17 | |           distribution: "zulu"
+18 | |           cache: "gradle"
+19 | |           java-version: "17"
    | |____________________________^ opt-in for caching here
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__cache_poisoning-8.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-8.snap
@@ -9,12 +9,12 @@ error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache pois
  1 | / on:
  2 | |   push:
  3 | |     tags:
- 4 | |       - '**'
+ 4 | |       - "**"
    | |____________^ generally used when publishing artifacts generated at runtime
  5 |
 ...
-15 |         - name: Setup CI caching
-16 |           uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
+17 |         - name: Setup CI caching
+18 |           uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cache enabled by default here
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__cache_poisoning-9.snap
+++ b/tests/snapshots/snapshot__cache_poisoning-9.snap
@@ -10,11 +10,11 @@ error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache pois
    |   ^^^^^^^^^^^ generally used when publishing artifacts generated at runtime
  5 |
 ...
-12 |           uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab # v1
-13 | /         with:
-14 | |           target: ${{ matrix.platform.target }}
-15 | |           args: --release --out dist
-16 | |           sccache: "true"
+14 |           uses: PyO3/maturin-action@ea5bac0f1ccd0ab11c805e2b804bfcb65dac2eab # v1
+15 | /         with:
+16 | |           target: ${{ matrix.platform.target }}
+17 | |           args: --release --out dist
+18 | |           sccache: "true"
    | |__________________________^ opt-in for caching here
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__excessive_permissions-2.snap
+++ b/tests/snapshots/snapshot__excessive_permissions-2.snap
@@ -3,12 +3,11 @@ source: tests/snapshot.rs
 expression: "zizmor().workflow(workflow_under_test(\"excessive-permissions/issue-336-repro.yml\")).args([\"--pedantic\"]).run()?"
 snapshot_kind: text
 ---
-error[excessive-permissions]: overly broad workflow or job-level permissions
- --> @@INPUT@@:3:1
+error[excessive-permissions]: overly broad permissions
+ --> @@INPUT@@:4:3
   |
-3 | / permissions:
-4 | |   contents: write
-  | |_________________^ contents: write is overly broad at the workflow level
+4 |   contents: write
+  |   ^^^^^^^^^^^^^^^ contents: write is overly broad at the workflow level
   |
   = note: audit confidence → High
 

--- a/tests/snapshots/snapshot__excessive_permissions-3.snap
+++ b/tests/snapshots/snapshot__excessive_permissions-3.snap
@@ -1,0 +1,33 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"excessive-permissions/workflow-default-perms.yml\")).args([\"--pedantic\"]).run()?"
+snapshot_kind: text
+---
+warning[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:1:1
+   |
+ 1 | / # two findings in pedantic mode: one for the entire workflow for having
+ 2 | | # implicit permissions (pedantic), and one for the 'single' job for having
+...  |
+12 | |         with:
+13 | |           persist-credentials: false
+   | |_____________________________________- default permissions used due to no permissions: block
+   |
+   = note: audit confidence → Medium
+
+warning[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:8:3
+   |
+ 8 | /   single:
+ 9 | |     runs-on: ubuntu-latest
+...  |
+12 | |         with:
+13 | |           persist-credentials: false
+   | |                                     -
+   | |_____________________________________|
+   |                                       this job
+   |                                       default permissions used due to no permissions: block
+   |
+   = note: audit confidence → Medium
+
+2 findings: 0 unknown, 0 informational, 0 low, 2 medium, 0 high

--- a/tests/snapshots/snapshot__excessive_permissions-4.snap
+++ b/tests/snapshots/snapshot__excessive_permissions-4.snap
@@ -1,0 +1,14 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"excessive-permissions/workflow-read-all.yml\")).run()?"
+snapshot_kind: text
+---
+warning[excessive-permissions]: overly broad permissions
+ --> @@INPUT@@:3:1
+  |
+3 | permissions: read-all
+  | --------------------- uses read-all permissions
+  |
+  = note: audit confidence → High
+
+1 finding: 0 unknown, 0 informational, 0 low, 1 medium, 0 high

--- a/tests/snapshots/snapshot__excessive_permissions-5.snap
+++ b/tests/snapshots/snapshot__excessive_permissions-5.snap
@@ -1,0 +1,14 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"excessive-permissions/workflow-write-all.yml\")).run()?"
+snapshot_kind: text
+---
+error[excessive-permissions]: overly broad permissions
+ --> @@INPUT@@:3:1
+  |
+3 | permissions: write-all
+  | ^^^^^^^^^^^^^^^^^^^^^^ uses write-all permissions
+  |
+  = note: audit confidence → High
+
+1 finding: 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/tests/snapshots/snapshot__excessive_permissions-6.snap
+++ b/tests/snapshots/snapshot__excessive_permissions-6.snap
@@ -1,0 +1,6 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"excessive-permissions/workflow-empty-perms.yml\")).run()?"
+snapshot_kind: text
+---
+No findings to report. Good job!

--- a/tests/snapshots/snapshot__excessive_permissions-7.snap
+++ b/tests/snapshots/snapshot__excessive_permissions-7.snap
@@ -1,0 +1,36 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"excessive-permissions/jobs-broaden-permissions.yml\")).run()?"
+snapshot_kind: text
+---
+warning[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:6:3
+   |
+ 6 | /   job1:
+ 7 | |     runs-on: ubuntu-latest
+ 8 | |     permissions: read-all
+   | |     --------------------- uses read-all permissions
+ 9 | |     steps:
+10 | |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+11 | |         with:
+12 | |           persist-credentials: false
+   | |____________________________________- this job
+   |
+   = note: audit confidence → High
+
+error[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:14:3
+   |
+14 | /   job2:
+15 | |     runs-on: ubuntu-latest
+16 | |     permissions: write-all
+   | |     ^^^^^^^^^^^^^^^^^^^^^^ uses write-all permissions
+17 | |     steps:
+18 | |       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+19 | |         with:
+20 | |           persist-credentials: false
+   | |_____________________________________^ this job
+   |
+   = note: audit confidence → High
+
+2 findings: 0 unknown, 0 informational, 0 low, 1 medium, 1 high

--- a/tests/snapshots/snapshot__excessive_permissions-8.snap
+++ b/tests/snapshots/snapshot__excessive_permissions-8.snap
@@ -1,0 +1,30 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"excessive-permissions/workflow-write-explicit.yml\")).run()?"
+snapshot_kind: text
+---
+error[excessive-permissions]: overly broad permissions
+ --> @@INPUT@@:5:3
+  |
+5 |   contents: write
+  |   ^^^^^^^^^^^^^^^ contents: write is overly broad at the workflow level
+  |
+  = note: audit confidence → High
+
+error[excessive-permissions]: overly broad permissions
+ --> @@INPUT@@:6:3
+  |
+6 |   id-token: write
+  |   ^^^^^^^^^^^^^^^ id-token: write is overly broad at the workflow level
+  |
+  = note: audit confidence → High
+
+note[excessive-permissions]: overly broad permissions
+ --> @@INPUT@@:7:3
+  |
+7 |   nonexistent: write
+  |   ------------------ note: nonexistent: write is overly broad at the workflow level
+  |
+  = note: audit confidence → High
+
+3 findings: 1 unknown, 0 informational, 0 low, 0 medium, 2 high

--- a/tests/snapshots/snapshot__excessive_permissions-9.snap
+++ b/tests/snapshots/snapshot__excessive_permissions-9.snap
@@ -1,0 +1,6 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"excessive-permissions/workflow-default-perms-all-jobs-explicit.yml\")).run()?"
+snapshot_kind: text
+---
+No findings to report. Good job! (1 suppressed)

--- a/tests/snapshots/snapshot__github_env-2.snap
+++ b/tests/snapshots/snapshot__github_env-2.snap
@@ -4,11 +4,11 @@ expression: "zizmor().workflow(workflow_under_test(\"github-env/github-path.yml\
 snapshot_kind: text
 ---
 error[github-env]: dangerous use of environment file
-  --> @@INPUT@@:12:9
+  --> @@INPUT@@:14:9
    |
-12 | /         run: |
-13 | |           message=$(echo "$TITLE" | grep -oP '[{\[][^}\]]+[}\]]' | sed 's/{\|}\|\[\|\]//g')
-14 | |           echo "$message" >> $GITHUB_PATH
+14 | /         run: |
+15 | |           message=$(echo "$TITLE" | grep -oP '[{\[][^}\]]+[}\]]' | sed 's/{\|}\|\[\|\]//g')
+16 | |           echo "$message" >> $GITHUB_PATH
    | |__________________________________________^ write to GITHUB_PATH may allow code execution
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__github_env-3.snap
+++ b/tests/snapshots/snapshot__github_env-3.snap
@@ -4,11 +4,11 @@ expression: "zizmor().workflow(workflow_under_test(\"github-env/issue-397-repro.
 snapshot_kind: text
 ---
 error[github-env]: dangerous use of environment file
-  --> @@INPUT@@:12:9
+  --> @@INPUT@@:14:9
    |
-12 | /         run: |
-13 | |           message=$(echo "$TITLE" | grep -oP '[{\[][^}\]]+[}\]]' | sed 's/{\|}\|\[\|\]//g')
-14 | |           echo "$message" >> $GITHUB_PATH
+14 | /         run: |
+15 | |           message=$(echo "$TITLE" | grep -oP '[{\[][^}\]]+[}\]]' | sed 's/{\|}\|\[\|\]//g')
+16 | |           echo "$message" >> $GITHUB_PATH
    | |_________________________________________^ write to GITHUB_PATH may allow code execution
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__insecure_commands-2.snap
+++ b/tests/snapshots/snapshot__insecure_commands-2.snap
@@ -4,12 +4,12 @@ expression: "zizmor().workflow(workflow_under_test(\"insecure-commands.yml\")).r
 snapshot_kind: text
 ---
 error[insecure-commands]: execution of insecure workflow commands is enabled
- --> @@INPUT@@:8:5
-  |
-8 | /     env:
-9 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
-  | |__________________________________________^ insecure commands enabled here
-  |
-  = note: audit confidence → High
+  --> @@INPUT@@:10:5
+   |
+10 | /     env:
+11 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
+   | |__________________________________________^ insecure commands enabled here
+   |
+   = note: audit confidence → High
 
 2 findings (1 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/tests/snapshots/snapshot__insecure_commands.snap
+++ b/tests/snapshots/snapshot__insecure_commands.snap
@@ -4,18 +4,18 @@ expression: "zizmor().workflow(workflow_under_test(\"insecure-commands.yml\")).a
 snapshot_kind: text
 ---
 error[insecure-commands]: execution of insecure workflow commands is enabled
- --> @@INPUT@@:8:5
-  |
-8 | /     env:
-9 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
-  | |__________________________________________^ insecure commands enabled here
-  |
-  = note: audit confidence → High
+  --> @@INPUT@@:10:5
+   |
+10 | /     env:
+11 | |       ACTIONS_ALLOW_UNSECURE_COMMANDS: yes
+   | |__________________________________________^ insecure commands enabled here
+   |
+   = note: audit confidence → High
 
 error[insecure-commands]: execution of insecure workflow commands is enabled
-  --> @@INPUT@@:22:9
+  --> @@INPUT@@:24:9
    |
-22 |         env: ${{ matrix.env }}
+24 |         env: ${{ matrix.env }}
    |         ^^^^^^^^^^^^^^^^^^^^^^ non-static environment may contain ACTIONS_ALLOW_UNSECURE_COMMANDS
    |
    = note: audit confidence → Low

--- a/tests/snapshots/snapshot__secrets_inherit.snap
+++ b/tests/snapshots/snapshot__secrets_inherit.snap
@@ -4,12 +4,12 @@ expression: "zizmor().workflow(workflow_under_test(\"secrets-inherit.yml\")).run
 snapshot_kind: text
 ---
 warning[secrets-inherit]: secrets unconditionally inherited by called workflow
- --> @@INPUT@@:5:5
+ --> @@INPUT@@:7:5
   |
-5 |     uses: octo-org/example-repo/.github/workflows/called-workflow.yml@main
+7 |     uses: octo-org/example-repo/.github/workflows/called-workflow.yml@main
   |     ---------------------------------------------------------------------- this reusable workflow
-6 |     # NOT OK: unconditionally inherits
-7 |     secrets: inherit
+8 |     # NOT OK: unconditionally inherits
+9 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

--- a/tests/snapshots/snapshot__self_hosted-3.snap
+++ b/tests/snapshots/snapshot__self_hosted-3.snap
@@ -4,9 +4,9 @@ expression: "zizmor().workflow(workflow_under_test(\"self-hosted/self-hosted-run
 snapshot_kind: text
 ---
 note[self-hosted-runner]: runs on a self-hosted runner
- --> @@INPUT@@:6:5
+ --> @@INPUT@@:8:5
   |
-6 |     runs-on: [self-hosted, linux, arm64]
+8 |     runs-on: [self-hosted, linux, arm64]
   |     ------------------------------------ note: self-hosted runner used here
   |
   = note: audit confidence → High

--- a/tests/snapshots/snapshot__self_hosted-4.snap
+++ b/tests/snapshots/snapshot__self_hosted-4.snap
@@ -4,10 +4,10 @@ expression: "zizmor().workflow(workflow_under_test(\"self-hosted/self-hosted-run
 snapshot_kind: text
 ---
 note[self-hosted-runner]: runs on a self-hosted runner
- --> @@INPUT@@:6:5
+ --> @@INPUT@@:8:5
   |
-6 | /     runs-on:
-7 | |       group: ubuntu-runners
+8 | /     runs-on:
+9 | |       group: ubuntu-runners
   | |___________________________- note: runner group implies self-hosted runner
   |
   = note: audit confidence → Low

--- a/tests/snapshots/snapshot__self_hosted-5.snap
+++ b/tests/snapshots/snapshot__self_hosted-5.snap
@@ -4,14 +4,14 @@ expression: "zizmor().workflow(workflow_under_test(\"self-hosted/self-hosted-mat
 snapshot_kind: text
 ---
 note[self-hosted-runner]: runs on a self-hosted runner
-  --> @@INPUT@@:8:5
+  --> @@INPUT@@:10:5
    |
- 6 |       runs-on: ${{ matrix.os }}
+ 8 |       runs-on: ${{ matrix.os }}
    |       ------------------------- note: expression may expand into a self-hosted runner
- 7 |
- 8 | /     strategy:
- 9 | |       matrix:
-10 | |         os: [self-hosted, ubuntu-latest]
+ 9 |
+10 | /     strategy:
+11 | |       matrix:
+12 | |         os: [self-hosted, ubuntu-latest]
    | |________________________________________- note: matrix declares self-hosted runner
    |
    = note: audit confidence → High

--- a/tests/snapshots/snapshot__self_hosted-6.snap
+++ b/tests/snapshots/snapshot__self_hosted-6.snap
@@ -4,16 +4,16 @@ expression: "zizmor().workflow(workflow_under_test(\"self-hosted/self-hosted-mat
 snapshot_kind: text
 ---
 note[self-hosted-runner]: runs on a self-hosted runner
-  --> @@INPUT@@:8:5
+  --> @@INPUT@@:10:5
    |
- 6 |       runs-on: ${{ matrix.os }}
+ 8 |       runs-on: ${{ matrix.os }}
    |       ------------------------- note: expression may expand into a self-hosted runner
- 7 |
- 8 | /     strategy:
- 9 | |       matrix:
-10 | |         os: [macOS-latest, ubuntu-latest]
-11 | |         include:
-12 | |           - os: self-hosted
+ 9 |
+10 | /     strategy:
+11 | |       matrix:
+12 | |         os: [macOS-latest, ubuntu-latest]
+13 | |         include:
+14 | |           - os: self-hosted
    | |___________________________- note: matrix declares self-hosted runner
    |
    = note: audit confidence → High

--- a/tests/snapshots/snapshot__self_hosted.snap
+++ b/tests/snapshots/snapshot__self_hosted.snap
@@ -1,14 +1,14 @@
 ---
 source: tests/snapshot.rs
-expression: "zizmor(&workflow_under_test(\"self-hosted.yml\"), &[\"--pedantic\"], false)?"
+expression: "zizmor().workflow(workflow_under_test(\"self-hosted.yml\")).args([\"--persona=auditor\"]).run()?"
 snapshot_kind: text
 ---
 note[self-hosted-runner]: runs on a self-hosted runner
- --> @@INPUT@@:8:5
-  |
-8 |     runs-on: [self-hosted, my-ubuntu-box]
-  |     ------------------------------------- note: self-hosted runner used here
-  |
-  = note: audit confidence → High
+  --> @@INPUT@@:10:5
+   |
+10 |     runs-on: [self-hosted, my-ubuntu-box]
+   |     ------------------------------------- note: self-hosted runner used here
+   |
+   = note: audit confidence → High
 
 1 finding: 1 unknown, 0 informational, 0 low, 0 medium, 0 high

--- a/tests/snapshots/snapshot__template_injection-2.snap
+++ b/tests/snapshots/snapshot__template_injection-2.snap
@@ -4,12 +4,12 @@ expression: "zizmor().workflow(workflow_under_test(\"template-injection/template
 snapshot_kind: text
 ---
 warning[template-injection]: code injection via template expansion
-  --> @@INPUT@@:17:9
+  --> @@INPUT@@:19:9
    |
-17 |         - name: Please dont
+19 |         - name: Please dont
    |           ----------------- this step
-18 | /         run: |
-19 | |           echo "doing a thing: ${{ matrix.dynamic }}"
+20 | /         run: |
+21 | |           echo "doing a thing: ${{ matrix.dynamic }}"
    | |______________________________________________________- matrix.dynamic may expand into attacker-controllable code
    |
    = note: audit confidence → Medium

--- a/tests/snapshots/snapshot__template_injection-4.snap
+++ b/tests/snapshots/snapshot__template_injection-4.snap
@@ -4,11 +4,11 @@ expression: "zizmor().workflow(workflow_under_test(\"template-injection/pr-317-r
 snapshot_kind: text
 ---
 warning[template-injection]: code injection via template expansion
-  --> @@INPUT@@:25:9
+  --> @@INPUT@@:27:9
    |
-25 |         - run: |
+27 |         - run: |
    |  _________-
-26 | |           echo ${{ matrix.bar }}
+28 | |           echo ${{ matrix.bar }}
    | |                                 -
    | |_________________________________|
    |                                   this step

--- a/tests/snapshots/snapshot__template_injection-5.snap
+++ b/tests/snapshots/snapshot__template_injection-5.snap
@@ -4,34 +4,34 @@ expression: "zizmor().workflow(workflow_under_test(\"template-injection/static-e
 snapshot_kind: text
 ---
 help[template-injection]: code injection via template expansion
-  --> @@INPUT@@:39:9
+  --> @@INPUT@@:41:9
    |
-39 |         - name: step-level-non-static
+41 |         - name: step-level-non-static
    |           --------------------------- help: this step
-40 | /         run: |
-41 | |           echo ${{ env.bar }}
+42 | /         run: |
+43 | |           echo ${{ env.bar }}
    | |_____________________________- help: env.bar may expand into attacker-controllable code
    |
    = note: audit confidence → High
 
 help[template-injection]: code injection via template expansion
-  --> @@INPUT@@:46:9
+  --> @@INPUT@@:48:9
    |
-46 |         - name: job-level-non-static
+48 |         - name: job-level-non-static
    |           -------------------------- help: this step
-47 | /         run: |
-48 | |           echo ${{ env.foo }}
+49 | /         run: |
+50 | |           echo ${{ env.foo }}
    | |_____________________________- help: env.foo may expand into attacker-controllable code
    |
    = note: audit confidence → High
 
 help[template-injection]: code injection via template expansion
-  --> @@INPUT@@:51:9
+  --> @@INPUT@@:53:9
    |
-51 |         - name: workflow-level-non-static
+53 |         - name: workflow-level-non-static
    |           ------------------------------- help: this step
-52 | /         run: |
-53 | |           echo ${{ env.quux }}
+54 | /         run: |
+55 | |           echo ${{ env.quux }}
    | |_______________________________- help: env.quux may expand into attacker-controllable code
    |
    = note: audit confidence → High

--- a/tests/snapshots/snapshot__unpinned_uses-2.snap
+++ b/tests/snapshots/snapshot__unpinned_uses-2.snap
@@ -4,33 +4,33 @@ expression: "zizmor().workflow(workflow_under_test(\"unpinned-uses.yml\")).run()
 snapshot_kind: text
 ---
 warning[unpinned-uses]: unpinned action reference
- --> @@INPUT@@:9:9
-  |
-9 |       - uses: actions/checkout
-  |         ---------------------- action is not pinned to a tag, branch, or hash ref
-  |
-  = note: audit confidence → High
+  --> @@INPUT@@:11:9
+   |
+11 |       - uses: actions/checkout
+   |         ---------------------- action is not pinned to a tag, branch, or hash ref
+   |
+   = note: audit confidence → High
 
 warning[unpinned-uses]: unpinned action reference
-  --> @@INPUT@@:19:9
+  --> @@INPUT@@:21:9
    |
-19 |       - uses: github/codeql-action/upload-sarif
+21 |       - uses: github/codeql-action/upload-sarif
    |         --------------------------------------- action is not pinned to a tag, branch, or hash ref
    |
    = note: audit confidence → High
 
 warning[unpinned-uses]: unpinned action reference
-  --> @@INPUT@@:22:9
+  --> @@INPUT@@:24:9
    |
-22 |       - uses: docker://ubuntu
+24 |       - uses: docker://ubuntu
    |         --------------------- action is not pinned to a tag, branch, or hash ref
    |
    = note: audit confidence → High
 
 warning[unpinned-uses]: unpinned action reference
-  --> @@INPUT@@:28:9
+  --> @@INPUT@@:30:9
    |
-28 |       - uses: docker://ghcr.io/pypa/gh-action-pypi-publish
+30 |       - uses: docker://ghcr.io/pypa/gh-action-pypi-publish
    |         -------------------------------------------------- action is not pinned to a tag, branch, or hash ref
    |
    = note: audit confidence → High

--- a/tests/snapshots/snapshot__unpinned_uses.snap
+++ b/tests/snapshots/snapshot__unpinned_uses.snap
@@ -1,44 +1,44 @@
 ---
 source: tests/snapshot.rs
-expression: "zizmor(Some(&workflow_under_test(\"unpinned-uses.yml\")), &[\"--pedantic\"],\nfalse)?"
+expression: "zizmor().workflow(workflow_under_test(\"unpinned-uses.yml\")).args([\"--pedantic\"]).run()?"
 snapshot_kind: text
 ---
 warning[unpinned-uses]: unpinned action reference
- --> @@INPUT@@:9:9
-  |
-9 |       - uses: actions/checkout
-  |         ---------------------- action is not pinned to a tag, branch, or hash ref
-  |
-  = note: audit confidence → High
+  --> @@INPUT@@:11:9
+   |
+11 |       - uses: actions/checkout
+   |         ---------------------- action is not pinned to a tag, branch, or hash ref
+   |
+   = note: audit confidence → High
 
 help[unpinned-uses]: unpinned action reference
-  --> @@INPUT@@:14:9
+  --> @@INPUT@@:16:9
    |
-14 |       - uses: actions/checkout@v3
+16 |       - uses: actions/checkout@v3
    |         ------------------------- help: action is not pinned to a hash ref
    |
    = note: audit confidence → High
 
 warning[unpinned-uses]: unpinned action reference
-  --> @@INPUT@@:19:9
+  --> @@INPUT@@:21:9
    |
-19 |       - uses: github/codeql-action/upload-sarif
+21 |       - uses: github/codeql-action/upload-sarif
    |         --------------------------------------- action is not pinned to a tag, branch, or hash ref
    |
    = note: audit confidence → High
 
 warning[unpinned-uses]: unpinned action reference
-  --> @@INPUT@@:22:9
+  --> @@INPUT@@:24:9
    |
-22 |       - uses: docker://ubuntu
+24 |       - uses: docker://ubuntu
    |         --------------------- action is not pinned to a tag, branch, or hash ref
    |
    = note: audit confidence → High
 
 warning[unpinned-uses]: unpinned action reference
-  --> @@INPUT@@:28:9
+  --> @@INPUT@@:30:9
    |
-28 |       - uses: docker://ghcr.io/pypa/gh-action-pypi-publish
+30 |       - uses: docker://ghcr.io/pypa/gh-action-pypi-publish
    |         -------------------------------------------------- action is not pinned to a tag, branch, or hash ref
    |
    = note: audit confidence → High

--- a/tests/test-data/artipacked.yml
+++ b/tests/test-data/artipacked.yml
@@ -6,6 +6,8 @@ on:
       - master
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   artipacked:
     runs-on: ubuntu-latest

--- a/tests/test-data/cache-poisoning.yml
+++ b/tests/test-data/cache-poisoning.yml
@@ -1,5 +1,6 @@
-on:
-  release
+on: release
+
+permissions: {}
 
 jobs:
   publish:

--- a/tests/test-data/cache-poisoning/caching-disabled-by-default.yml
+++ b/tests/test-data/cache-poisoning/caching-disabled-by-default.yml
@@ -1,5 +1,6 @@
-on:
-  release
+on: release
+
+permissions: {}
 
 jobs:
   publish:
@@ -13,8 +14,8 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
         with:
-          distribution: 'zulu'
-          java-version: '17'
+          distribution: "zulu"
+          java-version: "17"
 
       - name: Publish to Maven Central
         run: ./gradlew publishToMavenCentral --no-configuration-cache

--- a/tests/test-data/cache-poisoning/caching-enabled-by-default.yml
+++ b/tests/test-data/cache-poisoning/caching-enabled-by-default.yml
@@ -1,5 +1,6 @@
-on:
-  release
+on: release
+
+permissions: {}
 
 jobs:
   publish-crate:

--- a/tests/test-data/cache-poisoning/caching-not-configurable.yml
+++ b/tests/test-data/cache-poisoning/caching-not-configurable.yml
@@ -1,7 +1,9 @@
 on:
   push:
     tags:
-      - '**'
+      - "**"
+
+permissions: {}
 
 jobs:
   publish:

--- a/tests/test-data/cache-poisoning/caching-opt-in-boolean-toggle.yml
+++ b/tests/test-data/cache-poisoning/caching-opt-in-boolean-toggle.yml
@@ -1,5 +1,6 @@
-on:
-  release
+on: release
+
+permissions: {}
 
 jobs:
   publish:
@@ -13,7 +14,7 @@ jobs:
       - name: Setup DotNet
         uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: "5.0.x"
           cache: true
 
       - name: Publish on NuGet

--- a/tests/test-data/cache-poisoning/caching-opt-in-boolish-toggle.yml
+++ b/tests/test-data/cache-poisoning/caching-opt-in-boolish-toggle.yml
@@ -3,6 +3,8 @@
 
 on: release
 
+permissions: {}
+
 jobs:
   publish-crate:
     runs-on: ubuntu-24.04

--- a/tests/test-data/cache-poisoning/caching-opt-in-expression.yml
+++ b/tests/test-data/cache-poisoning/caching-opt-in-expression.yml
@@ -1,5 +1,6 @@
-on:
-  release
+on: release
+
+permissions: {}
 
 jobs:
   publish:

--- a/tests/test-data/cache-poisoning/caching-opt-in-multi-value-toggle.yml
+++ b/tests/test-data/cache-poisoning/caching-opt-in-multi-value-toggle.yml
@@ -1,5 +1,6 @@
-on:
-  release
+on: release
+
+permissions: {}
 
 jobs:
   publish:
@@ -13,9 +14,9 @@ jobs:
       - name: Setup JDK
         uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b
         with:
-          distribution: 'zulu'
-          cache: 'gradle'
-          java-version: '17'
+          distribution: "zulu"
+          cache: "gradle"
+          java-version: "17"
 
       - name: Publish to Maven Central
         run: ./gradlew publishToMavenCentral --no-configuration-cache

--- a/tests/test-data/cache-poisoning/caching-opt-out.yml
+++ b/tests/test-data/cache-poisoning/caching-opt-out.yml
@@ -1,5 +1,6 @@
-on:
-  release
+on: release
+
+permissions: {}
 
 jobs:
   publish-crate:

--- a/tests/test-data/cache-poisoning/issue-343-repro.yml
+++ b/tests/test-data/cache-poisoning/issue-343-repro.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - "v*.*.*"
 
+permissions: {}
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/tests/test-data/cache-poisoning/issue-378-repro.yml
+++ b/tests/test-data/cache-poisoning/issue-378-repro.yml
@@ -4,6 +4,8 @@ name: issue-378
 
 on: push
 
+permissions: {}
+
 jobs:
   issue-378:
     runs-on: ubuntu-latest

--- a/tests/test-data/cache-poisoning/no-cache-aware-steps.yml
+++ b/tests/test-data/cache-poisoning/no-cache-aware-steps.yml
@@ -1,5 +1,6 @@
-on:
-  release
+on: release
+
+permissions: {}
 
 jobs:
   publish-crate:

--- a/tests/test-data/cache-poisoning/publisher-step.yml
+++ b/tests/test-data/cache-poisoning/publisher-step.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: macos-latest

--- a/tests/test-data/cache-poisoning/workflow-release-branch-trigger.yml
+++ b/tests/test-data/cache-poisoning/workflow-release-branch-trigger.yml
@@ -1,7 +1,9 @@
 on:
   push:
     branches:
-      - 'release-v2.0.0'
+      - "release-v2.0.0"
+
+permissions: {}
 
 jobs:
   publish:

--- a/tests/test-data/cache-poisoning/workflow-tag-trigger.yml
+++ b/tests/test-data/cache-poisoning/workflow-tag-trigger.yml
@@ -1,7 +1,9 @@
 on:
   push:
     tags:
-      - '**'
+      - "**"
+
+permissions: {}
 
 jobs:
   publish:

--- a/tests/test-data/excessive-permissions/jobs-broaden-permissions.yml
+++ b/tests/test-data/excessive-permissions/jobs-broaden-permissions.yml
@@ -1,0 +1,20 @@
+on: push
+
+permissions: {}
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    permissions: read-all
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+  job2:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false

--- a/tests/test-data/excessive-permissions/workflow-default-perms-all-jobs-explicit.yml
+++ b/tests/test-data/excessive-permissions/workflow-default-perms-all-jobs-explicit.yml
@@ -1,0 +1,24 @@
+# two findings in pedantic mode: one for the entire workflow for having
+# implicit permissions (pedantic), and one for the 'single' job for having
+# implicit permissions
+
+on: push
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+  job2:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false

--- a/tests/test-data/excessive-permissions/workflow-default-perms.yml
+++ b/tests/test-data/excessive-permissions/workflow-default-perms.yml
@@ -1,0 +1,13 @@
+# two findings in pedantic mode: one for the entire workflow for having
+# implicit permissions (pedantic), and one for the 'single' job for having
+# implicit permissions
+
+on: push
+
+jobs:
+  single:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false

--- a/tests/test-data/excessive-permissions/workflow-empty-perms.yml
+++ b/tests/test-data/excessive-permissions/workflow-empty-perms.yml
@@ -1,0 +1,20 @@
+on: push
+
+# No findings because the workflow clears all permissions, and the jobs
+# inherit the cleared permissions.
+permissions: {}
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+  job2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false

--- a/tests/test-data/excessive-permissions/workflow-read-all.yml
+++ b/tests/test-data/excessive-permissions/workflow-read-all.yml
@@ -1,0 +1,18 @@
+on: push
+
+permissions: read-all
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+  job2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false

--- a/tests/test-data/excessive-permissions/workflow-write-all.yml
+++ b/tests/test-data/excessive-permissions/workflow-write-all.yml
@@ -1,0 +1,18 @@
+on: push
+
+permissions: write-all
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+  job2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false

--- a/tests/test-data/excessive-permissions/workflow-write-explicit.yml
+++ b/tests/test-data/excessive-permissions/workflow-write-explicit.yml
@@ -1,0 +1,25 @@
+on: push
+
+# Each of these is flagged as too broad.
+permissions:
+  contents: write
+  id-token: write
+  nonexistent: write
+
+jobs:
+  job1:
+    runs-on: ubuntu-latest
+    # not flagged because it's within the job scope
+    permissions:
+      deployments: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
+
+  job2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false

--- a/tests/test-data/github-env/github-path.yml
+++ b/tests/test-data/github-env/github-path.yml
@@ -1,6 +1,8 @@
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
 
+permissions: {}
+
 jobs:
   vulnerable:
     runs-on: ubuntu-latest

--- a/tests/test-data/github-env/issue-397-repro.yml
+++ b/tests/test-data/github-env/issue-397-repro.yml
@@ -1,6 +1,8 @@
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
 
+permissions: {}
+
 jobs:
   issue-397-repro:
     runs-on: ubuntu-latest

--- a/tests/test-data/github_env.yml
+++ b/tests/test-data/github_env.yml
@@ -1,6 +1,8 @@
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
 
+permissions: {}
+
 jobs:
   vulnerable:
     runs-on: ubuntu-latest

--- a/tests/test-data/hardcoded-credentials.yml
+++ b/tests/test-data/hardcoded-credentials.yml
@@ -7,6 +7,8 @@ on:
       - master
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/tests/test-data/inlined-ignores.yml
+++ b/tests/test-data/inlined-ignores.yml
@@ -4,6 +4,8 @@ on:
       - master
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   artipacked-ignored:
     runs-on: ubuntu-latest

--- a/tests/test-data/insecure-commands.yml
+++ b/tests/test-data/insecure-commands.yml
@@ -2,6 +2,8 @@ on: pull_request
 
 name: insecure-commands
 
+permissions: {}
+
 jobs:
   some-dangerous-job:
     runs-on: ubuntu-latest

--- a/tests/test-data/secrets-inherit.yml
+++ b/tests/test-data/secrets-inherit.yml
@@ -1,5 +1,7 @@
 on: push
 
+permissions: {}
+
 jobs:
   call-workflow-vulnerable-1:
     uses: octo-org/example-repo/.github/workflows/called-workflow.yml@main

--- a/tests/test-data/self-hosted.yml
+++ b/tests/test-data/self-hosted.yml
@@ -3,6 +3,8 @@
 on:
   push:
 
+permissions: {}
+
 jobs:
   whops:
     runs-on: [self-hosted, my-ubuntu-box]

--- a/tests/test-data/self-hosted/issue-283-repro.yml
+++ b/tests/test-data/self-hosted/issue-283-repro.yml
@@ -6,6 +6,8 @@ on:
       os:
         type: string
 
+permissions: {}
+
 jobs:
   deploy:
     runs-on: ${{inputs.os}}

--- a/tests/test-data/self-hosted/self-hosted-matrix-dimension.yml
+++ b/tests/test-data/self-hosted/self-hosted-matrix-dimension.yml
@@ -1,6 +1,8 @@
 on:
   push:
 
+permissions: {}
+
 jobs:
   whops:
     runs-on: ${{ matrix.os }}

--- a/tests/test-data/self-hosted/self-hosted-matrix-exclusion.yml
+++ b/tests/test-data/self-hosted/self-hosted-matrix-exclusion.yml
@@ -3,6 +3,8 @@
 on:
   push:
 
+permissions: {}
+
 jobs:
   ok:
     runs-on: ${{ matrix.os }}

--- a/tests/test-data/self-hosted/self-hosted-matrix-inclusion.yml
+++ b/tests/test-data/self-hosted/self-hosted-matrix-inclusion.yml
@@ -1,6 +1,8 @@
 on:
   push:
 
+permissions: {}
+
 jobs:
   whops:
     runs-on: ${{ matrix.os }}

--- a/tests/test-data/self-hosted/self-hosted-runner-group.yml
+++ b/tests/test-data/self-hosted/self-hosted-runner-group.yml
@@ -1,6 +1,8 @@
 on:
   push:
 
+permissions: {}
+
 jobs:
   whops:
     runs-on:

--- a/tests/test-data/self-hosted/self-hosted-runner-label.yml
+++ b/tests/test-data/self-hosted/self-hosted-runner-label.yml
@@ -1,6 +1,8 @@
 on:
   push:
 
+permissions: {}
+
 jobs:
   whops:
     runs-on: [self-hosted, linux, arm64]

--- a/tests/test-data/template-injection.yml
+++ b/tests/test-data/template-injection.yml
@@ -5,6 +5,8 @@ name: example
 on:
   issues:
 
+permissions: {}
+
 jobs:
   inject-me:
     runs-on: ubuntu-latest

--- a/tests/test-data/template-injection/issue-22-repro.yml
+++ b/tests/test-data/template-injection/issue-22-repro.yml
@@ -6,6 +6,8 @@ name: JIT
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   jit:
     name: ${{ matrix.target }} (${{ matrix.debug && 'Debug' || 'Release' }})
@@ -41,7 +43,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Native macOS
         if: runner.os == 'macOS'

--- a/tests/test-data/template-injection/issue-418-repro.yml
+++ b/tests/test-data/template-injection/issue-418-repro.yml
@@ -1,9 +1,13 @@
 # reproduction case for https://github.com/woodruffw/zizmor/issues/418
 
 name: Test
+
 on:
   issue_comment:
     types: [created]
+
+permissions: {}
+
 jobs:
   stop:
     runs-on: ubuntu-latest

--- a/tests/test-data/template-injection/pr-317-repro.yml
+++ b/tests/test-data/template-injection/pr-317-repro.yml
@@ -4,6 +4,8 @@ name: PR-317-REPRO
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   PR-317-REPRO:
     name: PR-317-REPRO

--- a/tests/test-data/template-injection/static-env.yml
+++ b/tests/test-data/template-injection/static-env.yml
@@ -8,6 +8,8 @@ env:
   baz: baz
   quux: ${{ github.event.issue.title }}
 
+permissions: {}
+
 jobs:
   static-env-1:
     name: static-env

--- a/tests/test-data/template-injection/template-injection-dynamic-matrix.yml
+++ b/tests/test-data/template-injection/template-injection-dynamic-matrix.yml
@@ -4,6 +4,8 @@ name: paw-me
 on:
   issues:
 
+permissions: {}
+
 jobs:
   not-ok:
     runs-on: ubuntu-latest

--- a/tests/test-data/template-injection/template-injection-static-matrix.yml
+++ b/tests/test-data/template-injection/template-injection-static-matrix.yml
@@ -4,6 +4,8 @@ name: safe
 on:
   issues:
 
+permissions: {}
+
 jobs:
   ok-ish:
     runs-on: ubuntu-latest

--- a/tests/test-data/unpinned-uses.yml
+++ b/tests/test-data/unpinned-uses.yml
@@ -1,6 +1,8 @@
 name: example
 on: [push]
 
+permissions: {}
+
 jobs:
   unpinned-0:
     runs-on: ubuntu-latest

--- a/tests/test-data/unpinned-uses/issue-433-repro.yml
+++ b/tests/test-data/unpinned-uses/issue-433-repro.yml
@@ -4,6 +4,8 @@ name: issue-433-repro
 
 on: push
 
+permissions: {}
+
 jobs:
   issue-433-repro:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This refactors `excessive-permissions` to correctly handle implicit permissions at the workflow level, which it now flags as equivalent to the default `$GITHUB_TOKEN`.

~~Needs docs and more snapshot tests.~~

Closes #429.