### PR TITLE
bugfix: mark another context as safe during injections

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,11 @@ of `zizmor`.
 * The [excessive-permissions] audit has been refactored, and better captures
   both true positive and true negative cases (#441)
 
+### Fixed
+
+* The [template-injection] audit no longer considers `github.event.pull_request.base.sha`
+  dangerous (#445)
+
 ## v1.1.1
 
 ### Fixed

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -44,6 +44,7 @@ const SAFE_CONTEXTS: &[&str] = &[
     "github.event.issue.number",
     "github.event.merge_group.base_sha",
     "github.event.number",
+    "github.event.pull_request.base.sha",
     "github.event.pull_request.commits", // number of commits in PR
     "github.event.pull_request.number",  // the PR's own number
     "github.event.workflow_run.id",


### PR DESCRIPTION
`github.event.pull_request.base.sha` is always a SHA reference.