### PR TITLE
bugfix: sarif: use absolute physical locations only

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,9 @@ of `zizmor`.
   as unpinned/unhashed (#439)
 * The [excessive-permissions] audit has been refactored, and better captures
   both true positive and true negative cases (#441)
+* The SARIF output mode (`--format=sarif`) now always returns absolute paths
+  in its location information, rather than attempting to infer a (sometimes
+  incorrect) repository-relative path (#453)
 
 ### Fixed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,7 +394,7 @@ fn run() -> Result<ExitCode> {
         OutputFormat::Plain => render::render_findings(&registry, &results),
         OutputFormat::Json => serde_json::to_writer_pretty(stdout(), &results.findings())?,
         OutputFormat::Sarif => {
-            serde_json::to_writer_pretty(stdout(), &sarif::build(&registry, results.findings()))?
+            serde_json::to_writer_pretty(stdout(), &sarif::build(results.findings()))?
         }
     };
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -161,26 +161,6 @@ impl InputRegistry {
             .get(key)
             .expect("API misuse: requested an un-registered input")
     }
-
-    /// Returns a subjective relative path for the given workflow.
-    ///
-    /// In general, this will be a relative path within the repository root,
-    /// e.g. if zizmor was told to scan `/tmp/src` then one of the discovered
-    /// workflows might be `.github/workflows/ci.yml` relative to `/tmp/src`.
-    ///
-    /// The exceptional case here is when zizmor is asked to scan a single
-    /// workflow at some arbitrary location on disk. In that case, just
-    /// the base workflow filename itself is returned.
-    pub(crate) fn get_workflow_relative_path<'a>(&self, key: &'a InputKey) -> &'a str {
-        let path = key.path();
-
-        match path.rfind(".github/workflows") {
-            Some(start) => &path[start..],
-            // NOTE: Unwraps are safe since file component is always present and
-            // all paths are UTF-8 by construction.
-            None => key.filename(),
-        }
-    }
 }
 
 pub(crate) struct AuditRegistry {


### PR DESCRIPTION
This changes the SARIF generation so that `physicalLocations` now always contains an absolute path to the input. This is a slight over-correction of the previous behavior, which would use a repo-relative path when possible and fall back on the filename component when it couldn't infer one.

In practice, the trick used by the previous behavior worked well for workflow path (which are always under `.github/workflows` but doesn't generalize for action paths, which can be anywhere. As a result there's no "anchor" to distinguish the repository prefix from the rest of the path.

This should have no negative effect on most users: local users will have their full paths in the SARIF instead, as will remote (GitHub Actions) users. In the latter case, GitHub Advanced Security should be able to "rebase" the paths correctly.

Fixes #452.

