### PR TITLE
feat: bot-conditions

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,12 +9,12 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
-### Added
+### New Features 🌈
 
 * **New audit**: [bot-conditions] detects spoofable uses of `github.actor`
   within dangerous triggers (#460)
 
-### Improved
+### Improvements 🌱
 
 * The [unpinned-uses] audit no longer flags local reusable workflows or actions
   as unpinned/unhashed (#439)
@@ -25,7 +25,7 @@ of `zizmor`.
   incorrect) repository-relative path (#453)
 * `zizmor` now provides `manylinux` wheel builds for `aarch64` (#457)
 
-### Fixed
+### Bug Fixes 🐛
 
 * The [template-injection] audit no longer considers `github.event.pull_request.base.sha`
   dangerous (#445)
@@ -34,7 +34,7 @@ of `zizmor`.
 
 ## v1.1.1
 
-### Fixed
+### Bug Fixes 🐛
 
 * Fixed a regression where workflows with calls to unpinned reusable workflows
   would fail to parse (#437)
@@ -44,17 +44,17 @@ of `zizmor`.
 This release comes with one new audit ([secrets-inherit]), plus a slew
 of bugfixes and internal refactors that unblock future improvements!
 
-### Added
+### New Features 🌈
 
 * **New audit**: [secrets-inherit] detects use of `secrets: inherit` with
   reusable workflow calls (#408)
 
-### Improved
+### Improvements 🌱
 
 * The [template-injection] audit now detects injections in calls
   to @azure/cli and @azure/powershell (#421)
 
-### Fixed
+### Bug Fixes 🐛
 
 * The [template-injection] audit no longer consider `github.server_url`
   dangerous (#412)
@@ -66,12 +66,12 @@ of bugfixes and internal refactors that unblock future improvements!
 This is a small quality and bugfix release. Thank you to everybody
 who helped by reporting and shaking out bugs from our first stable release!
 
-### Improved
+### Improvements 🌱
 
 * The [github-env] audit now detects dangerous writes to `GITHUB_PATH`,
   is more precise, and can produce multiple findings per run block (#391)
 
-### Fixed
+### Bug Fixes 🐛
 
 * `workflow_call.secrets` keys with missing values are now parsed correctly (#388)
 * The [cache-poisoning] audit no longer incorrectly treats `docker/build-push-action` as
@@ -94,7 +94,7 @@ happen with a new major version.
 This stable release comes with a large number of new features as well
 as stability commitments for existing features; read more below!
 
-### Added
+### New Features 🌈
 
 * Composite actions (i.e. `action.yml` where the action is *not* a Docker
   or JavaScript action) are now supported, and are audited by default
@@ -115,7 +115,7 @@ as stability commitments for existing features; read more below!
     This can be used to connect to a GitHub Enterprise (GHE) instance
     instead of the default `github.com` instance.
 
-### Improved
+### Improvements 🌱
 
 * The [cache-poisoning] audit is now aware of common publishing actions
   and uses then to determine whether to produce a finding (#338, #341)
@@ -129,7 +129,7 @@ as stability commitments for existing features; read more below!
 * The [github-env] audit is now significantly more precise on `bash` and `pwsh`
   inputs (#354)
 
-### Fixed
+### Bug Fixes 🐛
 
 * The [excessive-permissions] audit is now less noisy on single-job workflows (#337)
 * Expressions like `function().foo.bar` are now parsed correctly (#340)

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,11 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Added
+
+* **New audit**: [bot-conditions] detects spoofable uses of `github.actor`
+  within dangerous triggers (#460)
+
 ### Improved
 
 * The [unpinned-uses] audit no longer flags local reusable workflows or actions
@@ -446,3 +451,4 @@ This is one of `zizmor`'s bigger recent releases! Key enhancements include:
 [template-injection]: ./audits.md#template-injection
 [secrets-inherit]: ./audits.md#secrets-inherit
 [unpinned-uses]: ./audits.md#unpinned-uses
+[bot-conditions]: ./audits.md#bot-conditions

--- a/src/audit/bot_conditions.rs
+++ b/src/audit/bot_conditions.rs
@@ -1,0 +1,29 @@
+use std::ops::Deref;
+
+use github_actions_models::workflow::Job;
+
+use super::{audit_meta, Audit};
+
+pub(crate) struct BotConditions;
+
+audit_meta!(BotConditions, "bot-conditions", "spoofable bot actor check");
+
+impl Audit for BotConditions {
+    fn new(_state: super::AuditState) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self)
+    }
+
+    fn audit_normal_job<'w>(
+        &self,
+        job: &super::Job<'w>,
+    ) -> anyhow::Result<Vec<super::Finding<'w>>> {
+        let Job::NormalJob(normal) = job.deref() else {
+            return Ok(vec![]);
+        };
+
+        todo!()
+    }
+}

--- a/src/audit/bot_conditions.rs
+++ b/src/audit/bot_conditions.rs
@@ -2,7 +2,7 @@ use github_actions_models::common::{expr::ExplicitExpr, If};
 
 use crate::{
     expr::{self, Expr},
-    finding::{Confidence, Persona},
+    finding::{Confidence, Severity},
     models::JobExt,
 };
 
@@ -24,6 +24,8 @@ impl Audit for BotConditions {
         &self,
         job: &super::NormalJob<'w>,
     ) -> anyhow::Result<Vec<super::Finding<'w>>> {
+        let mut findings = vec![];
+
         // TODO: Consider other triggers as well?
         // In practice we expect to mostly see this problem with `pull_request_target`
         // triggers inside of "automerge this Dependabot PR"-style workflows.
@@ -31,49 +33,106 @@ impl Audit for BotConditions {
             return Ok(vec![]);
         }
 
+        let mut conds = vec![];
         if let Some(If::Expr(expr)) = &job.r#if {
-            if let Some((confidence, persona)) = Self::bot_condition(expr) {
-                todo!()
-            }
-        };
+            conds.push((expr, job.location()));
+        }
 
-        todo!()
+        for step in job.steps() {
+            if let Some(If::Expr(expr)) = &step.r#if {
+                conds.push((expr, step.location()));
+            }
+        }
+
+        for (expr, loc) in conds {
+            if let Some(confidence) = Self::bot_condition(expr) {
+                findings.push(
+                    Self::finding()
+                        .severity(Severity::High)
+                        .confidence(confidence)
+                        .add_location(
+                            loc.with_keys(&["if".into()])
+                                .primary()
+                                .annotated("github.actor may be spoofable"),
+                        )
+                        .build(job.parent())?,
+                );
+            }
+        }
+
+        Ok(findings)
     }
 }
 
 impl BotConditions {
-    fn walk_tree(expr: &Expr, dominating: bool) -> (bool, bool) {
+    fn walk_tree_for_bot_condition(expr: &Expr, dominating: bool) -> (bool, bool) {
         match expr {
             // We can't easily analyze the call's semantics, but we can
             // check to see if any of the call's arguments are
             // bot conditions. We treat a call as non-dominating always.
-            Expr::Call { func: _, args } => args
+            Expr::Call {
+                func: _,
+                args: exprs,
+            }
+            | Expr::Context {
+                raw: _,
+                components: exprs,
+            } => exprs
                 .iter()
-                .map(|arg| Self::walk_tree(arg, false))
+                .map(|arg| Self::walk_tree_for_bot_condition(arg, false))
                 .reduce(|(bc, _), (bc_next, _)| (bc || bc_next, false))
                 .unwrap_or((false, dominating)),
-            Expr::Index(expr) => Self::walk_tree(expr, dominating),
-            Expr::Context { raw: _, components } => todo!(),
+            Expr::Index(expr) => Self::walk_tree_for_bot_condition(expr, dominating),
             Expr::BinOp { lhs, op, rhs } => match op {
-                // && is non-dominating.
-                expr::BinOp::And => todo!(),
                 // || is dominating.
-                expr::BinOp::Or => todo!(),
+                expr::BinOp::Or => {
+                    let (bc_lhs, _) = Self::walk_tree_for_bot_condition(lhs, true);
+                    let (bc_rhs, _) = Self::walk_tree_for_bot_condition(rhs, true);
+
+                    (bc_lhs || bc_rhs, true)
+                }
                 // == is trivially dominating.
-                expr::BinOp::Eq => todo!(),
-                // Unclear.
-                expr::BinOp::Neq => todo!(),
-                expr::BinOp::Gt => todo!(),
-                expr::BinOp::Ge => todo!(),
-                expr::BinOp::Lt => todo!(),
-                expr::BinOp::Le => todo!(),
+                expr::BinOp::Eq => match (lhs.as_ref(), rhs.as_ref()) {
+                    (Expr::Context { raw, .. }, Expr::String(s))
+                    | (Expr::String(s), Expr::Context { raw, .. }) => {
+                        if raw == "github.actor" && s.ends_with("[bot]") {
+                            (true, true)
+                        } else {
+                            (false, true)
+                        }
+                    }
+                    (lhs, rhs) => {
+                        let (bc_lhs, _) = Self::walk_tree_for_bot_condition(lhs, true);
+                        let (bc_rhs, _) = Self::walk_tree_for_bot_condition(rhs, true);
+
+                        (bc_lhs || bc_rhs, true)
+                    }
+                },
+                // Every other binop is non-dominating.
+                _ => {
+                    let (bc_lhs, _) = Self::walk_tree_for_bot_condition(lhs, false);
+                    let (bc_rhs, _) = Self::walk_tree_for_bot_condition(rhs, false);
+
+                    (bc_lhs || bc_rhs, false)
+                }
             },
-            Expr::UnOp { op, expr } => todo!(),
+            Expr::UnOp { op, expr } => match op {
+                // We don't really know what we're negating, so naively
+                // assume we're non-dominating.
+                //
+                // TODO: This is slightly incorrect, since we should
+                // treat `!(github.actor == 'dependabot[bot]')` as a
+                // negative case even though it has an interior bot condition.
+                // However, to model this correctly we need to go from a
+                // boolean condition to a three-state: `Some(bool)` for
+                // an explicitly toggled condition, and `None` for no condition.
+                expr::UnOp::Not => Self::walk_tree_for_bot_condition(expr, false),
+            },
             _ => (false, dominating),
         }
     }
 
-    fn bot_condition(expr: &str) -> Option<(Confidence, Persona)> {
+    fn bot_condition(expr: &str) -> Option<Confidence> {
         let Ok(expr) = (match ExplicitExpr::from_curly(expr) {
             Some(raw_expr) => Expr::parse(raw_expr.as_bare()),
             None => Expr::parse(expr),
@@ -87,8 +146,55 @@ impl BotConditions {
         // expression truth value. For example, `github.actor == 'dependabot[bot]' || foo`
         // has the bot condition as dominating, since regardless of `foo` the check
         // always passes if the actor is dependabot[bot].
-        let (has_bot_condition, condition_dominates) = Self::walk_tree(&expr, true);
+        match Self::walk_tree_for_bot_condition(&expr, true) {
+            // We have a bot condition and it dominates the expression.
+            (true, true) => Some(Confidence::High),
+            // We have a bot condition but it doesn't dominate the expression.
+            (true, false) => Some(Confidence::Medium),
+            // No bot condition.
+            (_, _) => None,
+        }
+    }
+}
 
-        None
+#[cfg(test)]
+mod tests {
+    use crate::{audit::bot_conditions::BotConditions, finding::Confidence};
+
+    #[test]
+    fn test_bot_condition() {
+        for (cond, confidence) in &[
+            // Trivial dominating cases.
+            ("github.actor == 'dependabot[bot]'", Confidence::High),
+            ("'dependabot[bot]' == github.actor", Confidence::High),
+            // Dominating cases with OR.
+            (
+                "'dependabot[bot]' == github.actor || true",
+                Confidence::High,
+            ),
+            (
+                "'dependabot[bot]' == github.actor || false",
+                Confidence::High,
+            ),
+            (
+                "'dependabot[bot]' == github.actor || github.actor == 'foobar'",
+                Confidence::High,
+            ),
+            (
+                "github.actor == 'foobar' || 'dependabot[bot]' == github.actor",
+                Confidence::High,
+            ),
+            // Non-dominating cases with AND.
+            (
+                "'dependabot[bot]' == github.actor && something.else",
+                Confidence::Medium,
+            ),
+            (
+                "something.else && 'dependabot[bot]' == github.actor",
+                Confidence::Medium,
+            ),
+        ] {
+            assert_eq!(BotConditions::bot_condition(cond).unwrap(), *confidence);
+        }
     }
 }

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 pub(crate) mod artipacked;
+pub(crate) mod bot_conditions;
 pub(crate) mod cache_poisoning;
 pub(crate) mod dangerous_triggers;
 pub(crate) mod excessive_permissions;

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,6 +365,7 @@ fn run() -> Result<ExitCode> {
     register_audit!(audit::github_env::GitHubEnv);
     register_audit!(audit::cache_poisoning::CachePoisoning);
     register_audit!(audit::secrets_inherit::SecretsInherit);
+    register_audit!(audit::bot_conditions::BotConditions);
 
     let mut results = FindingRegistry::new(&app, &config);
     {

--- a/src/models.rs
+++ b/src/models.rs
@@ -636,7 +636,10 @@ impl<'w> Step<'w> {
 
     /// Returns a symbolic location for this [`Step`].
     pub(crate) fn location(&self) -> SymbolicLocation<'w> {
-        self.parent.location().with_step(self)
+        self.parent
+            .location()
+            .with_step(self)
+            .annotated("this step")
     }
 
     /// Like [`Step::location`], except with the step's `name`

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -464,3 +464,12 @@ fn secrets_inherit() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn bot_conditions() -> Result<()> {
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("bot-conditions.yml"))
+        .run()?);
+
+    Ok(())
+}

--- a/tests/snapshots/snapshot__bot_conditions.snap
+++ b/tests/snapshots/snapshot__bot_conditions.snap
@@ -1,0 +1,46 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().workflow(workflow_under_test(\"bot-conditions.yml\")).run()?"
+snapshot_kind: text
+---
+error[dangerous-triggers]: use of fundamentally insecure workflow trigger
+ --> @@INPUT@@:1:1
+  |
+1 | on: pull_request_target
+  | ^^^^^^^^^^^^^^^^^^^^^^^ pull_request_target is almost always used insecurely
+  |
+  = note: audit confidence → Medium
+
+error[bot-conditions]: spoofable bot actor check
+ --> @@INPUT@@:8:5
+  |
+8 |     if: github.actor == 'dependabot[bot]'
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ github.actor may be spoofable
+  |
+  = note: audit confidence → High
+
+error[bot-conditions]: spoofable bot actor check
+  --> @@INPUT@@:12:9
+   |
+12 |         if: ${{ github.actor == 'dependabot[bot]' }}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ github.actor may be spoofable
+   |
+   = note: audit confidence → High
+
+error[bot-conditions]: spoofable bot actor check
+  --> @@INPUT@@:16:9
+   |
+16 |         if: ${{ github.actor == 'dependabot[bot]' && github.repository == 'example/example' }}
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ github.actor may be spoofable
+   |
+   = note: audit confidence → Medium
+
+error[bot-conditions]: spoofable bot actor check
+  --> @@INPUT@@:20:9
+   |
+20 |         if: github.actor == 'renovate[bot]'
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ github.actor may be spoofable
+   |
+   = note: audit confidence → High
+
+5 findings: 0 unknown, 0 informational, 0 low, 0 medium, 5 high

--- a/tests/test-data/bot-conditions.yml
+++ b/tests/test-data/bot-conditions.yml
@@ -1,0 +1,24 @@
+on: pull_request_target
+
+permissions: {}
+
+jobs:
+  hackme:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: vulnerable-1
+        run: echo hello
+        if: ${{ github.actor == 'dependabot[bot]' }}
+
+      - name: vulnerable-2
+        run: echo hello
+        if: ${{ github.actor == 'dependabot[bot]' && github.repository == 'example/example' }}
+
+      - name: vulnerable-3
+        run: echo hello
+        if: github.actor == 'renovate[bot]'
+
+      - name: not-vulnerable-4
+        run: echo hello
+        if: github.actor == 'notabot'


### PR DESCRIPTION
Implements the `bot-conditions` audit.

This audit isn't as precise as it could be (a few FPs are noted in the comments), but it's a decent start.

This also revealed some expr parser deficiencies, which I'll handle in a follow-up.

Closes #170.