### PR TITLE
bugfix: parse multi-line expressions correctly

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -31,6 +31,7 @@ of `zizmor`.
   dangerous (#445)
 * The [artipacked] audit now correctly handles the strings `'true'` and `'false'`
   as their boolean counterparts (#448)
+* Expressions that span multiple source lines are now parsed correctly (#461)
 
 ## v1.1.1
 

--- a/src/expr/expr.pest
+++ b/src/expr/expr.pest
@@ -3,7 +3,7 @@
 //! See: <https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions>
 
 /// Whitespace handling
-WHITESPACE = _{ " " }
+WHITESPACE = _{ " " | NEWLINE }
 
 // Misc notes:
 // I have pretty low confidence in this grammar -- it should parse the

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -369,6 +369,12 @@ mod tests {
 
     #[test]
     fn test_parse_expr_rule() -> Result<()> {
+        // Ensures that we parse multi-line expressions correctly.
+        let multiline = "github.repository_owner == 'Homebrew' &&
+        ((github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+        (github.event_name == 'pull_request_target' &&
+        (github.event.action == 'ready_for_review' || github.event.label.name == 'automerge-skip')))";
+
         let cases = &[
             "fromJSON(inputs.free-threading) && '--disable-gil' || ''",
             "foo || bar || baz",
@@ -382,6 +388,7 @@ mod tests {
             "(github.actor != 'github-actions[bot]' && github.actor) == 'BrewTestBot'",
             "foo()[0]",
             "fromJson(steps.runs.outputs.data).workflow_runs[0].id",
+            multiline,
         ];
 
         for case in cases {


### PR DESCRIPTION
This was revealed with #460 -- multi-line expressions are supported by GHA, but we weren't allowing newlines as a whitespace token.