### PR TITLE
chore: remove site-requirements.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@ all:
 	@echo "Run my targets individually!"
 
 .PHONY: site
-site: site-requirements.txt
-	uvx --with-requirements $< mkdocs build
+site:
+	uv run --no-project --only-group docs mkdocs build
 
 .PHONY: site-live
-site-live: site-requirements.txt
-	uvx --with-requirements $< mkdocs serve
+site-live:
+	uv run --no-project --only-group docs mkdocs serve
 
 .PHONY: snippets
 snippets: trophies sponsors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ build-backend = "maturin"
 
 [tool.maturin]
 bindings = "bin"
+
+[dependency-groups]
+docs = ["mkdocs ~= 1.6", "mkdocs-material[imaging] ~= 9.5"]

--- a/site-requirements.txt
+++ b/site-requirements.txt
@@ -1,2 +1,0 @@
-mkdocs ~= 1.6
-mkdocs-material[imaging] ~= 9.5


### PR DESCRIPTION
Everything is now in pyproject.toml, so we don't need the site-requirements.txt file anymore.