### PR TITLE
feat: improve error message when repo fetch fails

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,10 @@ Nothing to see here (yet!)
 * The [excessive-permissions] audit is now more precise about both
   reusable workflows and reusable workflow calls (#473)
 
+### Improvements 🌱
+
+* Fetch failures when running `zizmor org/repo` are now more informative (#475)
+
 ## v1.2.1
 
 This is a small corrective release for some SARIF behavior that

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,16 @@ fn collect_from_repo_slug(
             registry.register_input(workflow.into())?;
         }
     } else {
-        let inputs = client.fetch_audit_inputs(&slug)?;
+        let inputs = client.fetch_audit_inputs(&slug).with_context(|| {
+            tip(
+                format!(
+                    "couldn't collect inputs from https://github.com/{owner}/{repo}",
+                    owner = slug.owner,
+                    repo = slug.repo
+                ),
+                "confirm the repository exists and that you have access to it",
+            )
+        })?;
 
         tracing::info!(
             "collected {len} inputs from {owner}/{repo}",
@@ -267,7 +276,7 @@ fn collect_from_repo_slug(
             repo = slug.repo
         );
 
-        for input in client.fetch_audit_inputs(&slug)? {
+        for input in inputs {
             registry.register_input(input)?;
         }
     }


### PR DESCRIPTION
Fixes #474.

Old:

```
invalid gzip header
```

New:

```
error: couldn't collect inputs from https://github.com/fake/fake
 = note: confirm the repository exists and that you have access to it

Caused by:
    failed to fetch https://api.github.com/repos/fake/fake/tarball/HEAD: 404 Not Found
```