### PR TITLE
bugfix: collect actions from subdirectories of .github/workflows

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,11 @@ of `zizmor`.
 
 Nothing to see here (yet!)
 
+### Bug Fixes 🐛
+
+* Fixed a bug where `zizmor` would fail to discover actions within
+  subdirectories of `.github/workflows` (#477)
+
 ## v1.2.2
 
 ### Bug Fixes 🐛

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,7 +202,7 @@ fn collect_from_repo_dir(
             {
                 let action = Action::from_file(entry_path, Some(top_dir))?;
                 registry.register_input(action.into())?;
-            } else if entry_path.is_dir() && !entry_path.ends_with(".github/workflows") {
+            } else if entry_path.is_dir() {
                 // Recurse and limit the collection mode to only actions.
                 collect_from_repo_dir(top_dir, entry_path, &CollectionMode::ActionsOnly, registry)?;
             }


### PR DESCRIPTION
This ensures that we discover actions defined within subdirectories of `.github/workflows` correctly, e.g. `.github/workflows/foo/action.yml`

Fixes #394.