### PR TITLE
Add slash to avoid redirect

### DIFF
--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -121,7 +121,7 @@ macro_rules! audit_meta {
             }
 
             fn url() -> &'static str {
-                concat!("https://woodruffw.github.io/zizmor/audits#", $id)
+                concat!("https://woodruffw.github.io/zizmor/audits/#", $id)
             }
         }
     };


### PR DESCRIPTION
When clicking the links in warnings, like:

```
warning[excessive-permissions]: overly broad permissions
```

Takes you to a page like:
`https://woodruffw.github.io/zizmor/audits#excessive-permissions`

Which quickly redirects to:
`https://woodruffw.github.io/zizmor/audits/#excessive-permissions`

But we might as well link directly there, to avoid a little jump in the URL.