### PR TITLE
feat: improve parse error slightly

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -11,6 +11,11 @@ of `zizmor`.
 
 Nothing to see here (yet!)
 
+### Improvements 🌱
+
+* `zizmor` produces slightly more informative error messages when given
+  an invalid input file (#482)
+
 ### Bug Fixes 🐛
 
 * Fixed a bug where `zizmor` would fail to discover actions within

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -159,8 +159,8 @@ impl InputRegistry {
             Err(we) => match Action::from_file(path, prefix) {
                 Ok(action) => self.register_input(action.into()),
                 Err(ae) => Err(anyhow!("failed to register input as workflow or action"))
-                    .with_context(|| we)
-                    .with_context(|| ae),
+                    .with_context(|| format!("{ae:?}"))
+                    .with_context(|| format!("{we:?}")),
             },
         }
     }

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -128,6 +128,17 @@ fn test_conflicting_online_options() -> Result<()> {
 }
 
 #[test]
+fn test_invalid_inputs() -> Result<()> {
+    insta::assert_snapshot!(zizmor()
+        .output(OutputMode::Stderr)
+        .offline(true)
+        .workflow(workflow_under_test("invalid/invalid-workflow.yml"))
+        .run()?);
+
+    Ok(())
+}
+
+#[test]
 fn artipacked() -> Result<()> {
     insta::assert_snapshot!(zizmor()
         .workflow(workflow_under_test("artipacked.yml"))

--- a/tests/snapshots/snapshot__invalid_inputs.snap
+++ b/tests/snapshots/snapshot__invalid_inputs.snap
@@ -1,0 +1,17 @@
+---
+source: tests/snapshot.rs
+expression: "zizmor().output(OutputMode::Stderr).offline(true).workflow(workflow_under_test(\"invalid/invalid-workflow.yml\")).run()?"
+snapshot_kind: text
+---
+failed to register input: @@INPUT@@
+
+Caused by:
+    0: invalid GitHub Actions workflow: file://@@INPUT@@
+       
+       Caused by:
+           jobs: data did not match any variant of untagged enum Job at line 10 column 3
+    1: invalid GitHub Actions definition: file://@@INPUT@@
+       
+       Caused by:
+           missing field `runs`
+    2: failed to register input as workflow or action

--- a/tests/test-data/invalid/invalid-workflow.yml
+++ b/tests/test-data/invalid/invalid-workflow.yml
@@ -1,0 +1,14 @@
+name: "invalid-workflow"
+
+on:
+  repository_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  invalid:
+    name: "invalid"
+
+    steps:
+      - run: echo hello


### PR DESCRIPTION
This slightly improves the parse error when loading an arbitrary file, by showing the entire error stack for both the failed workflow parse and the failed composite action parse.