### PR TITLE
deps: bump github-actions-models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "github-actions-models"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4c30fa8bf11e002d3ca72233e7a7bac33ffce4dc50877d63a8f5a161e0cd84"
+checksum = "f2269402e4d8fe06d41aa858a0fe15a49842764334d0aacc52f5f41e11466e30"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ clap-verbosity-flag = { version = "3.0.2", features = [
 ], default-features = false }
 etcetera = "0.8.0"
 flate2 = "1.0.35"
-github-actions-models = "0.22.0"
+github-actions-models = "0.23.0"
 http-cache-reqwest = "0.15.0"
 human-panic = "2.0.1"
 indexmap = "2.7.1"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,8 @@ Nothing to see here (yet!)
 
 * Fixed a bug where `zizmor` would fail to discover actions within
   subdirectories of `.github/workflows` (#477)
+* Fixed a bug where `zizmor` would fail to parse composite action definitions
+  with no `name` field (#487)
 
 ## v1.2.2
 


### PR DESCRIPTION
This fixes a bug where we'd fail to parse Action
definitions that are missing a `name`.