### PR TITLE
refactor: improve context handling

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -20,6 +20,8 @@ of `zizmor`.
 
 * `zizmor` produces slightly more informative error messages when given
   an invalid input file (#482)
+* Case insensitivity in contexts is now handeled more consistently
+  and pervasively (#491)
 
 ### Bug Fixes 🐛
 

--- a/src/audit/bot_conditions.rs
+++ b/src/audit/bot_conditions.rs
@@ -74,7 +74,7 @@ impl BotConditions {
                 args: exprs,
             }
             | Expr::Context(Context {
-                full: _,
+                raw: _,
                 components: exprs,
             }) => exprs
                 .iter()
@@ -132,10 +132,13 @@ impl BotConditions {
     }
 
     fn bot_condition(expr: &str) -> Option<Confidence> {
-        let Ok(expr) = (match ExplicitExpr::from_curly(expr) {
-            Some(raw_expr) => Expr::parse(raw_expr.as_bare()),
-            None => Expr::parse(expr),
-        }) else {
+        // TODO: Remove clones here.
+        let bare = match ExplicitExpr::from_curly(expr) {
+            Some(raw_expr) => raw_expr.as_bare().to_string(),
+            None => expr.to_string(),
+        };
+
+        let Ok(expr) = Expr::parse(&bare) else {
             tracing::warn!("couldn't parse expression: {expr}");
             return None;
         };

--- a/src/audit/overprovisioned_secrets.rs
+++ b/src/audit/overprovisioned_secrets.rs
@@ -1,5 +1,5 @@
 use crate::{
-    expr::Expr,
+    expr::{Context, Expr},
     finding::{Confidence, Feature, Location, Severity},
     utils::extract_expressions,
 };
@@ -69,7 +69,7 @@ impl OverprovisionedSecrets {
                 if func.eq_ignore_ascii_case("toJSON")
                     && args
                         .iter()
-                        .any(|arg| matches!(arg, Expr::Context { raw, components: _ } if raw.eq_ignore_ascii_case("secrets")))
+                        .any(|arg| matches!(arg, Expr::Context(ctx) if ctx == "secrets"))
                 {
                     results.push(());
                 } else {
@@ -77,9 +77,10 @@ impl OverprovisionedSecrets {
                 }
             }
             Expr::Index(expr) => results.extend(Self::secrets_expansions(expr)),
-            Expr::Context { raw: _, components } => {
-                results.extend(components.iter().flat_map(Self::secrets_expansions))
-            }
+            Expr::Context(Context {
+                full: _,
+                components,
+            }) => results.extend(components.iter().flat_map(Self::secrets_expansions)),
             Expr::BinOp { lhs, op: _, rhs } => {
                 results.extend(Self::secrets_expansions(lhs));
                 results.extend(Self::secrets_expansions(rhs));

--- a/src/audit/overprovisioned_secrets.rs
+++ b/src/audit/overprovisioned_secrets.rs
@@ -77,10 +77,9 @@ impl OverprovisionedSecrets {
                 }
             }
             Expr::Index(expr) => results.extend(Self::secrets_expansions(expr)),
-            Expr::Context(Context {
-                full: _,
-                components,
-            }) => results.extend(components.iter().flat_map(Self::secrets_expansions)),
+            Expr::Context(Context { raw: _, components }) => {
+                results.extend(components.iter().flat_map(Self::secrets_expansions))
+            }
             Expr::BinOp { lhs, op: _, rhs } => {
                 results.extend(Self::secrets_expansions(lhs));
                 results.extend(Self::secrets_expansions(rhs));

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -203,6 +203,7 @@ impl TemplateInjection {
                         Confidence::Low,
                         Persona::default(),
                     ));
+                // TODO: Handle env being case-insensitive.
                 } else if let Some(env) = context.as_str().strip_prefix("env.") {
                     let env_is_static = step.env_is_static(env);
 
@@ -214,7 +215,7 @@ impl TemplateInjection {
                             Persona::default(),
                         ));
                     }
-                } else if context.child_of("github.event") || context.child_of("github") {
+                } else if context.child_of("github") {
                     // TODO: Filter these more finely; not everything in the event
                     // context is actually attacker-controllable.
                     bad_expressions.push((

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -203,8 +203,7 @@ impl TemplateInjection {
                         Confidence::Low,
                         Persona::default(),
                     ));
-                // TODO: Handle env being case-insensitive.
-                } else if let Some(env) = context.as_str().strip_prefix("env.") {
+                } else if let Some(env) = context.pop_if("env") {
                     let env_is_static = step.env_is_static(env);
 
                     if !env_is_static {

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -10,8 +10,6 @@
 //! A small amount of additional processing is done to remove template
 //! expressions that an attacker can't control.
 
-use std::sync::LazyLock;
-
 use github_actions_models::{
     common::{expr::LoE, Uses},
     workflow::job::Strategy,
@@ -35,54 +33,52 @@ audit_meta!(
 );
 
 /// Contexts that are believed to be always safe.
-const SAFE_CONTEXTS: LazyLock<&[&str]> = LazyLock::new(|| {
-    &[
-        // The action path is always safe.
-        "github.action_path",
-        // The GitHub event name (i.e. trigger) is itself safe.
-        "github.event_name",
-        // Safe keys within the otherwise generally unsafe github.event context.
-        "github.event.after",  // hexadecimal SHA ref
-        "github.event.before", // hexadecimal SHA ref
-        "github.event.issue.number",
-        "github.event.merge_group.base_sha",
-        "github.event.number",
-        "github.event.pull_request.base.sha",
-        "github.event.pull_request.commits", // number of commits in PR
-        "github.event.pull_request.number",  // the PR's own number
-        "github.event.workflow_run.id",
-        // Information about the GitHub repository
-        "github.repository",
-        "github.repository_id",
-        "github.repositoryUrl",
-        // Information about the GitHub repository owner (account/org or ID)
-        "github.repository_owner",
-        "github.repository_owner_id",
-        // Unique numbers assigned by GitHub for workflow runs
-        "github.run_attempt",
-        "github.run_id",
-        "github.run_number",
-        // Typically something like `https://github.com`; you have bigger problems if
-        // this is attacker-controlled.
-        "github.server_url",
-        // Always a 40-char SHA-1 reference.
-        "github.sha",
-        // Like `secrets.*`: not safe to expose, but safe to interpolate.
-        "github.token",
-        // GitHub Actions-controlled local directory.
-        "github.workspace",
-        // GitHub Actions-controller runner architecture.
-        "runner.arch",
-        // Debug logging is (1) or is not (0) enabled on GitHub Actions runner.
-        "runner.debug",
-        // GitHub Actions runner operating system.
-        "runner.os",
-        // GitHub Actions temporary directory, value controlled by the runner itself.
-        "runner.temp",
-        // GitHub Actions cached tool directory, value controlled by the runner itself.
-        "runner.tool_cache",
-    ]
-});
+const SAFE_CONTEXTS: &[&str] = &[
+    // The action path is always safe.
+    "github.action_path",
+    // The GitHub event name (i.e. trigger) is itself safe.
+    "github.event_name",
+    // Safe keys within the otherwise generally unsafe github.event context.
+    "github.event.after",  // hexadecimal SHA ref
+    "github.event.before", // hexadecimal SHA ref
+    "github.event.issue.number",
+    "github.event.merge_group.base_sha",
+    "github.event.number",
+    "github.event.pull_request.base.sha",
+    "github.event.pull_request.commits", // number of commits in PR
+    "github.event.pull_request.number",  // the PR's own number
+    "github.event.workflow_run.id",
+    // Information about the GitHub repository
+    "github.repository",
+    "github.repository_id",
+    "github.repositoryUrl",
+    // Information about the GitHub repository owner (account/org or ID)
+    "github.repository_owner",
+    "github.repository_owner_id",
+    // Unique numbers assigned by GitHub for workflow runs
+    "github.run_attempt",
+    "github.run_id",
+    "github.run_number",
+    // Typically something like `https://github.com`; you have bigger problems if
+    // this is attacker-controlled.
+    "github.server_url",
+    // Always a 40-char SHA-1 reference.
+    "github.sha",
+    // Like `secrets.*`: not safe to expose, but safe to interpolate.
+    "github.token",
+    // GitHub Actions-controlled local directory.
+    "github.workspace",
+    // GitHub Actions-controller runner architecture.
+    "runner.arch",
+    // Debug logging is (1) or is not (0) enabled on GitHub Actions runner.
+    "runner.debug",
+    // GitHub Actions runner operating system.
+    "runner.os",
+    // GitHub Actions temporary directory, value controlled by the runner itself.
+    "runner.temp",
+    // GitHub Actions cached tool directory, value controlled by the runner itself.
+    "runner.tool_cache",
+];
 
 impl TemplateInjection {
     fn script_with_location<'s>(

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -23,7 +23,7 @@ impl Context {
     /// it's a "bare" context string, i.e. doesn't begin with a function call.
     pub(crate) fn from_str(ctx: &str) -> Self {
         // TODO: Use Rule::context to parse here instead?
-        let components = ctx.split('.').map(|c| Expr::ident(c)).collect::<Vec<_>>();
+        let components = ctx.split('.').map(Expr::ident).collect::<Vec<_>>();
 
         Self {
             full: ctx.to_string(),
@@ -67,13 +67,13 @@ impl Context {
         }
 
         // If we've exhausted the parent, then the child is a true child.
-        return parent_components.next().is_none();
+        parent_components.next().is_none()
     }
 }
 
-impl Into<Context> for &str {
-    fn into(self) -> Context {
-        Context::from_str(self)
+impl From<&str> for Context {
+    fn from(val: &str) -> Self {
+        Context::from_str(val)
     }
 }
 

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -387,6 +387,11 @@ mod tests {
             // Trivial child cases.
             ("foo", true),
             ("foo.bar", true),
+            // Case-insensitive cases.
+            ("FOO", true),
+            ("FOO.BAR", true),
+            ("Foo", true),
+            ("Foo.Bar", true),
             // We consider a context to be a child of itself.
             ("foo.bar.baz", true),
             // Trivial non-child cases.

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -61,9 +61,9 @@ impl<'src> Context<'src> {
 
     /// Returns the tail of the context if the head matches the given string.
     pub(crate) fn pop_if(&self, head: &str) -> Option<&str> {
-        match self.components().get(0)? {
+        match self.components().first()? {
             Expr::Identifier(ident) if ident.eq_ignore_ascii_case(head) => {
-                Some(&self.raw.split_once('.').unwrap().1)
+                Some(self.raw.split_once('.')?.1)
             }
             _ => None,
         }
@@ -428,7 +428,7 @@ mod tests {
             ("foo.", None),
             ("bar", None),
         ] {
-            assert_eq!(ctx.pop_if(*case), *expected);
+            assert_eq!(ctx.pop_if(case), *expected);
         }
     }
 
@@ -568,7 +568,7 @@ mod tests {
             (
                 "foo(1, 2, 3)",
                 Expr::Call {
-                    func: "foo".into(),
+                    func: "foo",
                     args: vec![Expr::Number(1.0), Expr::Number(2.0), Expr::Number(3.0)],
                 },
             ),


### PR DESCRIPTION
This refactors context handling to be more generic/consistent. In particular, it aims to ensure that we do case-insensitive context comparisons as often as possible, since that's what GitHub itself does (i.e. `github.ref == GITHUB.REF`).

It also removes a few more persistent sources of unneeded allocations/reallocations of strings, although there's still a lot that could be done there.