### PR TITLE
Downgrade tracing-indicatif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-indicatif"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8201ca430e0cd893ef978226fd3516c06d9c494181c8bf4e5b32e30ed4b40aa1"
+checksum = "74ba258e9de86447f75edf6455fded8e5242704c6fccffe7bf8d7fb6daef1180"
 dependencies = [
  "indicatif",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tar = "0.4.43"
 terminal-link = "0.1.0"
 tokio = { version = "1.43.0", features = ["rt-multi-thread"] }
 tracing = "0.1.41"
-tracing-indicatif = "0.3.9"
+tracing-indicatif = "0.3.8"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tree-sitter = "0.24.7"
 tree-sitter-bash = "0.23.3"


### PR DESCRIPTION
Zizmor v1.2.2 installed via Cargo does not compile on ubuntu (works fine on MacOS though).
Example:
-  https://github.com/pypi/warehouse/actions/runs/13011768769/job/36290925535
- https://github.com/huggingface/peft/actions/runs/13009492925/job/36283783626

The problem stems from `tracing-indicatif`:

```bash
root@8c9cc7047c95:/zizmor# CARGO_TARGET_DIR=/tmp/cargo-install5wZQo3/ cargo install zizmor --version 1.2.2 --jobs=1
    Updating crates.io index
  Installing zizmor v1.2.2
    Updating crates.io index
     Locking 314 packages to latest compatible versions
      Adding github-actions-models v0.22.0 (available: v0.23.0)
warning: profile package spec `insta` in profile `dev` did not match any packages

        Did you mean `idna`?
warning: profile package spec `similar` in profile `dev` did not match any packages
   Compiling tracing-indicatif v0.3.9
error[E0277]: `OnceCell<String>` cannot be shared between threads safely
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-indicatif-0.3.9/src/lib.rs:661:20
    |
661 |           ext.insert(IndicatifSpanContext {
    |  _____________------_^
    | |             |
    | |             required by a bound introduced by this call
662 | |             progress_bar: None,
663 | |             pb_init_settings: ProgressBarInitSettings::default(),
664 | |             parent_progress_bar: None,
...   |
669 | |             level,
670 | |         });
    | |_________^ `OnceCell<String>` cannot be shared between threads safely
    |
    = help: within `IndicatifSpanContext`, the trait `Sync` is not implemented for `OnceCell<String>`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::OnceLock` instead
note: required because it appears within the type `indicatif::state::TabExpandedString`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/indicatif-0.17.10/src/state.rs:354:17
    |
354 | pub(crate) enum TabExpandedString {
    |                 ^^^^^^^^^^^^^^^^^
note: required because it appears within the type `style::TemplatePart`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/indicatif-0.17.10/src/style.rs:634:6
    |
634 | enum TemplatePart {
    |      ^^^^^^^^^^^^
note: required because it appears within the type `PhantomData<style::TemplatePart>`
   --> /rustc/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/core/src/marker.rs:753:12
note: required because it appears within the type `alloc::raw_vec::RawVec<style::TemplatePart>`
   --> /rustc/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/alloc/src/raw_vec.rs:76:19
note: required because it appears within the type `Vec<style::TemplatePart>`
   --> /rustc/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/alloc/src/vec/mod.rs:397:12
note: required because it appears within the type `style::Template`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/indicatif-0.17.10/src/style.rs:466:8
    |
466 | struct Template {
    |        ^^^^^^^^
note: required because it appears within the type `ProgressStyle`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/indicatif-0.17.10/src/style.rs:21:12
    |
21  | pub struct ProgressStyle {
    |            ^^^^^^^^^^^^^
note: required because it appears within the type `Option<ProgressStyle>`
   --> /rustc/9fc6b43126469e3858e2fe86cafb4f0fd5068869/library/core/src/option.rs:572:10
note: required because it appears within the type `ProgressBarInitSettings`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-indicatif-0.3.9/src/lib.rs:169:8
    |
169 | struct ProgressBarInitSettings {
    |        ^^^^^^^^^^^^^^^^^^^^^^^
note: required because it appears within the type `IndicatifSpanContext`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-indicatif-0.3.9/src/lib.rs:176:8
    |
176 | struct IndicatifSpanContext {
    |        ^^^^^^^^^^^^^^^^^^^^
note: required by a bound in `ExtensionsMut::<'a>::insert`
   --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-subscriber-0.3.19/src/registry/extensions.rs:87:29
    |
87  |     pub fn insert<T: Send + Sync + 'static>(&mut self, val: T) {
    |                             ^^^^ required by this bound in `ExtensionsMut::<'a>::insert`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `tracing-indicatif` (lib) due to 1 previous error
error: failed to compile `zizmor v1.2.2`, intermediate artifacts can be found at `/tmp/cargo-install5wZQo3/`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```

Downgrading to `tracing-indicatif==0.3.8` hotfixes the problem.