### PR TITLE
bugfix: bump github-actions-models to 0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "github-actions-models"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7708850aeb44563406e3ac4a0f4651757a167b328b9d416b4b06a0a22814cca6"
+checksum = "d3d33cc977e9aaa73b0e447c5c387e1720dcdfbc54e7f86e32c76e2a78bfcb9c"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ clap-verbosity-flag = { version = "3.0.2", features = [
 ], default-features = false }
 etcetera = "0.8.0"
 flate2 = "1.0.35"
-github-actions-models = "0.24.0"
+github-actions-models = "0.25.0"
 http-cache-reqwest = "0.15.1"
 human-panic = "2.0.1"
 indexmap = "2.7.1"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,6 +24,8 @@ of `zizmor`.
   correctly (#511)
 * Fixed a false positive in [ref-confusion] where partial tag matches were
   incorrectly considered confusable (#519)
+* Fixed a bug where `zizmor` would fail to parse workflow definitions with
+  an expression inside `strategy.max-parallel` (#522)
 
 ## v1.3.0
 


### PR DESCRIPTION
Fixes an edge case in modeling `max-parallel`; see https://github.com/woodruffw/github-actions-models/issues/35.