### PR TITLE
feat: relax ignore comment regex

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,8 @@ of `zizmor`.
 
 * SARIF outputs are now slightly more aligned with GitHub Code Scanning
   expectations (#528)
+* `# zizmor: ignore[rule]` comments can now have trailing explanations,
+  e.g. `# zizmor: ignore[rule] because reasons` (#531)
 
 ## v1.3.1
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -287,6 +287,12 @@ For example, to ignore a single `artipacked` finding:
 uses: actions/checkout@v3 # zizmor: ignore[artipacked]
 ```
 
+Ignore comments can also have a trailing explanation:
+
+```yaml title="example.yml"
+uses: actions/checkout@v3 # zizmor: ignore[artipacked] this is actually fine
+```
+
 ### With `zizmor.yml`
 
 When ignoring multiple findings (or entire files), a `zizmor.yml` configuration

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -282,7 +282,7 @@ impl From<&yamlpath::Location> for ConcreteLocation {
 static ANY_COMMENT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"#.*$").unwrap());
 
 static IGNORE_EXPR: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"# zizmor: ignore\[(.+)\]\s*$").unwrap());
+    LazyLock::new(|| Regex::new(r"# zizmor: ignore\[(.+)\](?:\s+.*)?$").unwrap());
 
 /// Represents a single source comment.
 #[derive(Debug, Serialize)]
@@ -510,6 +510,14 @@ mod tests {
             ("# zizmor: ignore[foo, bar,   foo-bar]", "foo-bar", true),
             // Extra commas and duplicates are nonsense but OK.
             ("# zizmor: ignore[foo,foo,,foo,,,,foo,]", "foo", true),
+            // Trailing content with a space is OK.
+            ("# zizmor: ignore[foo] some other stuff", "foo", true),
+            // Trailing spaces are OK.
+            ("# zizmor: ignore[foo] ", "foo", true),
+            ("# zizmor: ignore[foo]  ", "foo", true),
+            ("# zizmor: ignore[foo]   ", "foo", true),
+            // Trailing content without a space is not OK.
+            ("# zizmor: ignore[foo]some other stuff", "foo", false),
             // Valid ignore, but not a match.
             ("# zizmor: ignore[foo,bar]", "baz", false),
             // Invalid ignore: empty rule list.


### PR DESCRIPTION
We now allow trailing comments after the ignore rule list, which is useful for self-documenting ignores.

Closes #513.