### PR TITLE
logging: Don't include a timestamp in log lines

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -346,6 +346,7 @@ fn run() -> Result<ExitCode> {
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
+                .without_time()
                 .with_ansi(std::io::stderr().is_terminal())
                 .with_writer(indicatif_layer.get_stderr_writer()),
         )


### PR DESCRIPTION
Fixes #542