### PR TITLE
Revert "chore: cargo: actually bump the edition (#553)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Update Rust toolchain
-        run: rustup update
-
       - name: Format
         run: cargo fmt && git diff --exit-code
 
@@ -33,9 +30,6 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         persist-credentials: false
-
-    - name: Update Rust toolchain
-      run: rustup update
 
     - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "zizmor"
 description = "Static analysis for GitHub Actions"
 version = "1.3.1"
-edition = "2024"
+edition = "2021"
 repository = "https://github.com/woodruffw/zizmor"
 homepage = "https://github.com/woodruffw/zizmor"
 documentation = "https://woodruffw.github.io/zizmor/"
@@ -10,7 +10,7 @@ authors = ["William Woodruff <william@yossarian.net>"]
 license = "MIT"
 keywords = ["cli", "github-actions", "static-analysis", "security"]
 categories = ["command-line-utilities"]
-rust-version = "1.85.0"
+rust-version = "1.80.1"
 
 [features]
 # Test-only: enable online audits that make use of a GitHub token via GH_TOKEN.

--- a/src/audit/artipacked.rs
+++ b/src/audit/artipacked.rs
@@ -2,16 +2,16 @@ use std::ops::Deref as _;
 
 use anyhow::Result;
 use github_actions_models::{
-    common::{EnvValue, Uses, expr::ExplicitExpr},
+    common::{expr::ExplicitExpr, EnvValue, Uses},
     workflow::job::StepBody,
 };
 use itertools::Itertools as _;
 
-use super::{Audit, audit_meta};
+use super::{audit_meta, Audit};
 use crate::utils::split_patterns;
 use crate::{
     finding::{Confidence, Finding, Persona, Severity},
-    models::{JobExt, uses::RepositoryUsesExt as _},
+    models::{uses::RepositoryUsesExt as _, JobExt},
     state::AuditState,
 };
 

--- a/src/audit/bot_conditions.rs
+++ b/src/audit/bot_conditions.rs
@@ -1,6 +1,6 @@
-use github_actions_models::common::{If, expr::ExplicitExpr};
+use github_actions_models::common::{expr::ExplicitExpr, If};
 
-use super::{Audit, audit_meta};
+use super::{audit_meta, Audit};
 use crate::{
     expr::{self, Context, Expr},
     finding::{Confidence, Severity},

--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -2,10 +2,10 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 
 use github_actions_models::common::Uses;
-use github_actions_models::workflow::Trigger;
 use github_actions_models::workflow::event::{BareEvent, BranchFilters, OptionalBody};
+use github_actions_models::workflow::Trigger;
 
-use crate::audit::{Audit, audit_meta};
+use crate::audit::{audit_meta, Audit};
 use crate::finding::{Confidence, Finding, Severity};
 use crate::models::coordinate::{ActionCoordinate, Control, ControlFieldType, Toggle, Usage};
 use crate::models::{JobExt as _, NormalJob, Step, StepCommon, Steps};

--- a/src/audit/dangerous_triggers.rs
+++ b/src/audit/dangerous_triggers.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use super::{Audit, audit_meta};
+use super::{audit_meta, Audit};
 use crate::finding::{Confidence, Finding, Severity};
 use crate::models::Workflow;
 use crate::state::AuditState;

--- a/src/audit/excessive_permissions.rs
+++ b/src/audit/excessive_permissions.rs
@@ -2,11 +2,11 @@ use std::{collections::HashMap, sync::LazyLock};
 
 use github_actions_models::common::{BasePermission, Permission, Permissions};
 
-use super::{Audit, Job, audit_meta};
+use super::{audit_meta, Audit, Job};
 use crate::models::JobExt as _;
 use crate::{
-    AuditState,
     finding::{Confidence, Persona, Severity, SymbolicLocation},
+    AuditState,
 };
 
 // Subjective mapping of permissions to severities, when given `write` access.

--- a/src/audit/hardcoded_container_credentials.rs
+++ b/src/audit/hardcoded_container_credentials.rs
@@ -3,7 +3,7 @@ use github_actions_models::{
     workflow::job::{Container, DockerCredentials},
 };
 
-use super::{Audit, Job, audit_meta};
+use super::{audit_meta, Audit, Job};
 use crate::{
     finding::{Confidence, Severity},
     models::JobExt as _,

--- a/src/audit/impostor_commit.rs
+++ b/src/audit/impostor_commit.rs
@@ -5,14 +5,14 @@
 //!
 //! [`clank`]: https://github.com/chainguard-dev/clank
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use github_actions_models::common::{RepositoryUses, Uses};
 
-use super::{Audit, Job, audit_meta};
+use super::{audit_meta, Audit, Job};
 use crate::{
     finding::{Confidence, Finding, Severity},
     github_api::{self, ComparisonStatus},
-    models::{JobExt as _, Workflow, uses::RepositoryUsesExt as _},
+    models::{uses::RepositoryUsesExt as _, JobExt as _, Workflow},
     state::AuditState,
 };
 

--- a/src/audit/insecure_commands.rs
+++ b/src/audit/insecure_commands.rs
@@ -6,7 +6,7 @@ use github_actions_models::common::expr::LoE;
 use github_actions_models::common::{Env, EnvValue};
 use github_actions_models::workflow::job::StepBody;
 
-use super::{Job, audit_meta};
+use super::{audit_meta, Job};
 use crate::audit::Audit;
 use crate::finding::{Confidence, Finding, Persona, Severity, SymbolicLocation};
 use crate::models::{JobExt as _, Steps, Workflow};

--- a/src/audit/known_vulnerable_actions.rs
+++ b/src/audit/known_vulnerable_actions.rs
@@ -5,10 +5,10 @@
 //!
 //! See: <https://docs.github.com/en/rest/security-advisories/global-advisories?apiVersion=2022-11-28>
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use github_actions_models::common::{RepositoryUses, Uses};
 
-use super::{Audit, audit_meta};
+use super::{audit_meta, Audit};
 use crate::finding::Finding;
 use crate::models::CompositeStep;
 use crate::{

--- a/src/audit/overprovisioned_secrets.rs
+++ b/src/audit/overprovisioned_secrets.rs
@@ -4,7 +4,7 @@ use crate::{
     utils::extract_expressions,
 };
 
-use super::{Audit, AuditInput, audit_meta};
+use super::{audit_meta, Audit, AuditInput};
 
 pub(crate) struct OverprovisionedSecrets;
 

--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -6,10 +6,10 @@
 //! but the upstream repository may host *both* a branch and a tag named
 //! `foo`, making it unclear to the end user which is selected.
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use github_actions_models::common::{RepositoryUses, Uses};
 
-use super::{Audit, Job, audit_meta};
+use super::{audit_meta, Audit, Job};
 use crate::finding::Finding;
 use crate::models::{CompositeStep, JobExt as _};
 use crate::{

--- a/src/audit/secrets_inherit.rs
+++ b/src/audit/secrets_inherit.rs
@@ -1,6 +1,6 @@
 use github_actions_models::workflow::job::Secrets;
 
-use super::{Audit, audit_meta};
+use super::{audit_meta, Audit};
 use crate::{finding::Confidence, models::JobExt as _};
 
 pub(crate) struct SecretsInherit;

--- a/src/audit/self_hosted_runner.rs
+++ b/src/audit/self_hosted_runner.rs
@@ -11,12 +11,12 @@ use github_actions_models::{
     workflow::job::RunsOn,
 };
 
-use super::{Audit, Job, audit_meta};
+use super::{audit_meta, Audit, Job};
 use crate::models::Matrix;
 use crate::{
-    AuditState,
     finding::{Confidence, Persona, Severity},
     models::JobExt as _,
+    AuditState,
 };
 
 pub(crate) struct SelfHostedRunner;

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -11,15 +11,15 @@
 //! expressions that an attacker can't control.
 
 use github_actions_models::{
-    common::{Uses, expr::LoE},
+    common::{expr::LoE, Uses},
     workflow::job::Strategy,
 };
 
-use super::{Audit, audit_meta};
+use super::{audit_meta, Audit};
 use crate::{
     expr::{BinOp, Expr, UnOp},
     finding::{Confidence, Persona, Severity, SymbolicLocation},
-    models::{self, StepCommon, uses::RepositoryUsesExt as _},
+    models::{self, uses::RepositoryUsesExt as _, StepCommon},
     state::AuditState,
     utils::extract_expressions,
 };

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -1,8 +1,8 @@
 use github_actions_models::common::Uses;
 
-use super::{Audit, AuditState, Finding, Step, audit_meta};
+use super::{audit_meta, Audit, AuditState, Finding, Step};
 use crate::finding::{Confidence, Persona, Severity};
-use crate::models::{CompositeStep, uses::UsesExt as _};
+use crate::models::{uses::UsesExt as _, CompositeStep};
 
 pub(crate) struct UnpinnedUses;
 

--- a/src/audit/unredacted_secrets.rs
+++ b/src/audit/unredacted_secrets.rs
@@ -1,11 +1,11 @@
 use crate::{
-    Confidence, Severity,
     expr::{Context, Expr},
     finding::{Feature, Location},
     utils::extract_expressions,
+    Confidence, Severity,
 };
 
-use super::{Audit, audit_meta};
+use super::{audit_meta, Audit};
 
 pub(crate) struct UnredactedSecrets;
 

--- a/src/audit/use_trusted_publishing.rs
+++ b/src/audit/use_trusted_publishing.rs
@@ -7,7 +7,7 @@ use github_actions_models::{
 };
 use indexmap::IndexMap;
 
-use super::{Audit, audit_meta};
+use super::{audit_meta, Audit};
 use crate::{
     finding::{Confidence, Severity},
     models::uses::RepositoryUsesExt as _,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, fs, num::NonZeroUsize, str::FromStr};
 
-use anyhow::{Context as _, Result, anyhow};
-use serde::{Deserialize, de};
+use anyhow::{anyhow, Context as _, Result};
+use serde::{de, Deserialize};
 
-use crate::{App, finding::Finding};
+use crate::{finding::Finding, App};
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct WorkflowRule {

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -1,8 +1,8 @@
 //! Expression parsing and analysis.
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use itertools::Itertools;
-use pest::{Parser, iterators::Pair};
+use pest::{iterators::Pair, Parser};
 use pest_derive::Parser;
 
 /// A parser for GitHub Actions' expression language.
@@ -580,19 +580,33 @@ mod tests {
                 "foo.bar.baz",
                 Expr::context(
                     "foo.bar.baz",
-                    [Expr::ident("foo"), Expr::ident("bar"), Expr::ident("baz")],
-                ),
+                    [Expr::ident("foo"), Expr::ident("bar"), Expr::ident("baz")]
+                )
             ),
             (
                 "foo.bar.baz[1][2]",
                 Expr::context(
                     "foo.bar.baz[1][2]",
                     [
-                        Expr::ident("foo"),
-                        Expr::ident("bar"),
-                        Expr::ident("baz"),
-                        Expr::Index(Expr::Number(1.0).into()),
-                        Expr::Index(Expr::Number(2.0).into()),
+                        Expr::ident(
+                            "foo",
+                        ),
+                        Expr::ident(
+                            "bar",
+                        ),
+                        Expr::ident(
+                            "baz",
+                        ),
+                        Expr::Index(
+                            Expr::Number(
+                                1.0,
+                            ).into(),
+                        ),
+                        Expr::Index(
+                            Expr::Number(
+                                2.0,
+                            ).into(),
+                        ),
                     ],
                 ),
             ),
@@ -601,10 +615,18 @@ mod tests {
                 Expr::context(
                     "foo.bar.baz[*]",
                     [
-                        Expr::ident("foo"),
-                        Expr::ident("bar"),
-                        Expr::ident("baz"),
-                        Expr::Index(Expr::Star.into()),
+                        Expr::ident(
+                            "foo",
+                        ),
+                        Expr::ident(
+                            "bar",
+                        ),
+                        Expr::ident(
+                            "baz",
+                        ),
+                        Expr::Index(
+                            Expr::Star.into(),
+                        ),
                     ],
                 ),
             ),
@@ -613,9 +635,13 @@ mod tests {
                 Expr::context(
                     "vegetables.*.ediblePortions",
                     vec![
-                        Expr::ident("vegetables"),
+                        Expr::ident(
+                            "vegetables",
+                        ),
                         Expr::Star,
-                        Expr::ident("ediblePortions"),
+                        Expr::ident(
+                            "ediblePortions",
+                        ),
                     ],
                 ),
             ),
@@ -628,20 +654,20 @@ mod tests {
                         lhs: Expr::BinOp {
                             lhs: Expr::context(
                                 "github.ref",
-                                [Expr::ident("github"), Expr::ident("ref")],
-                            )
-                            .into(),
+                                [
+                                    Expr::ident("github"),
+                                    Expr::ident("ref"),
+                                ],
+                            ).into(),
                             op: BinOp::Eq,
                             rhs: Expr::string("refs/heads/main"),
-                        }
-                        .into(),
+                        }.into(),
                         op: BinOp::And,
                         rhs: Expr::string("value_for_main_branch"),
-                    }
-                    .into(),
+                    }.into(),
                     op: BinOp::Or,
                     rhs: Expr::string("value_for_other_branches"),
-                },
+                }
             ),
             (
                 "(true || false) == true",
@@ -649,12 +675,11 @@ mod tests {
                     lhs: Expr::BinOp {
                         lhs: Expr::Boolean(true).into(),
                         op: BinOp::Or,
-                        rhs: Expr::Boolean(false).into(),
-                    }
-                    .into(),
+                        rhs: Expr::Boolean(false).into()
+                    }.into(),
                     op: BinOp::Eq,
-                    rhs: Expr::Boolean(true).into(),
-                },
+                    rhs: Expr::Boolean(true).into()
+                }
             ),
             (
                 "!(!true || false)",
@@ -663,14 +688,11 @@ mod tests {
                     expr: Expr::BinOp {
                         lhs: Expr::UnOp {
                             op: UnOp::Not,
-                            expr: Expr::Boolean(true).into(),
-                        }
-                        .into(),
-                        op: BinOp::Or,
-                        rhs: Expr::Boolean(false).into(),
-                    }
-                    .into(),
-                },
+                            expr: Expr::Boolean(true).into()
+                        }.into(),
+                    op: BinOp::Or, rhs: Expr::Boolean(false).into()
+                    }.into()
+                }
             ),
         ];
 

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{borrow::Cow, ops::Range, sync::LazyLock};
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use clap::ValueEnum;
 use line_index::{LineCol, TextSize};
 use regex::Regex;
@@ -267,12 +267,12 @@ impl From<&yamlpath::Location> for ConcreteLocation {
     fn from(value: &yamlpath::Location) -> Self {
         Self {
             start_point: Point {
-                row: value.point_span.0.0,
-                column: value.point_span.0.1,
+                row: value.point_span.0 .0,
+                column: value.point_span.0 .1,
             },
             end_point: Point {
-                row: value.point_span.1.0,
-                column: value.point_span.1.1,
+                row: value.point_span.1 .0,
+                column: value.point_span.1 .1,
             },
             offset_span: value.byte_span.0..value.byte_span.1,
         }

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -5,7 +5,7 @@
 
 use std::{io::Read, ops::Deref, path::Path};
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use camino::Utf8Path;
 use flate2::read::GzDecoder;
 use github_actions_models::common::RepositoryUses;
@@ -14,11 +14,11 @@ use http_cache_reqwest::{
 };
 use owo_colors::OwoColorize;
 use reqwest::{
+    header::{HeaderMap, ACCEPT, AUTHORIZATION, USER_AGENT},
     StatusCode,
-    header::{ACCEPT, AUTHORIZATION, HeaderMap, USER_AGENT},
 };
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
-use serde::{Deserialize, de::DeserializeOwned};
+use serde::{de::DeserializeOwned, Deserialize};
 use tar::Archive;
 use tracing::instrument;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::{io::stdout, process::ExitCode, str::FromStr};
 
 use annotate_snippets::{Level, Renderer};
 use anstream::{eprintln, stream::IsTerminal};
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use audit::Audit;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Parser, ValueEnum};
@@ -16,9 +16,9 @@ use models::Action;
 use owo_colors::OwoColorize;
 use registry::{AuditRegistry, FindingRegistry, InputRegistry};
 use state::AuditState;
-use tracing::{Span, info_span, instrument};
-use tracing_indicatif::{IndicatifLayer, span_ext::IndicatifSpanExt};
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _, util::SubscriberInitExt as _};
+use tracing::{info_span, instrument, Span};
+use tracing_indicatif::{span_ext::IndicatifSpanExt, IndicatifLayer};
+use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter};
 
 mod audit;
 mod config;

--- a/src/models.rs
+++ b/src/models.rs
@@ -5,17 +5,17 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::{iter::Enumerate, ops::Deref};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use camino::Utf8Path;
-use github_actions_models::common::Env;
 use github_actions_models::common::expr::LoE;
+use github_actions_models::common::Env;
 use github_actions_models::workflow::event::{BareEvent, OptionalBody};
 use github_actions_models::workflow::job::{RunsOn, Strategy};
-use github_actions_models::workflow::{self, Trigger, job, job::StepBody};
+use github_actions_models::workflow::{self, job, job::StepBody, Trigger};
 use github_actions_models::{action, common};
 use indexmap::IndexMap;
 use line_index::LineIndex;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use terminal_link::Link;
 
 use crate::finding::{Route, SymbolicLocation};

--- a/src/models/coordinate.rs
+++ b/src/models/coordinate.rs
@@ -13,7 +13,7 @@
 // able to express things like
 // "match foo/bar if foo: A and not bar: B and baz: /abcd/"
 
-use github_actions_models::common::{EnvValue, Uses, expr::ExplicitExpr};
+use github_actions_models::common::{expr::ExplicitExpr, EnvValue, Uses};
 
 use super::{StepBodyCommon, StepCommon};
 use crate::models::uses::RepositoryUsesExt as _;

--- a/src/models/uses.rs
+++ b/src/models/uses.rs
@@ -46,7 +46,7 @@ impl RepositoryUsesExt for RepositoryUses {
             && self.repo.eq_ignore_ascii_case(&template.repo)
             && self.subpath.as_ref().map(|s| s.to_lowercase())
                 == template.subpath.as_ref().map(|s| s.to_lowercase())
-            && template.git_ref.as_ref().is_none_or(|git_ref| {
+            && template.git_ref.as_ref().map_or(true, |git_ref| {
                 Some(git_ref.to_lowercase()) == self.git_ref.as_ref().map(|r| r.to_lowercase())
             })
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -3,7 +3,7 @@
 
 use std::{fmt::Display, process::ExitCode};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use github_actions_models::common::RepositoryUses;
 use indexmap::IndexMap;
@@ -11,11 +11,11 @@ use serde::Serialize;
 use tracing::instrument;
 
 use crate::{
-    App,
     audit::{Audit, AuditInput},
     config::Config,
     finding::{Confidence, Finding, Persona, Severity},
     models::{Action, Workflow},
+    App,
 };
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize)]
@@ -247,7 +247,7 @@ impl<'a> FindingRegistry<'a> {
             } else {
                 if self
                     .highest_seen_severity
-                    .is_none_or(|s| finding.determinations.severity > s)
+                    .map_or(true, |s| finding.determinations.severity > s)
                 {
                     self.highest_seen_severity = Some(finding.determinations.severity);
                 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,6 +1,6 @@
 //! APIs for rendering zizmor's "plain" (i.e. terminal) output format.
 
-use std::collections::{HashMap, hash_map::Entry};
+use std::collections::{hash_map::Entry, HashMap};
 
 use annotate_snippets::{Level, Renderer, Snippet};
 use anstream::{eprintln, print, println};
@@ -8,9 +8,9 @@ use owo_colors::OwoColorize;
 use terminal_link::Link;
 
 use crate::{
-    App,
     finding::{Finding, Location, Severity},
     registry::{FindingRegistry, InputKey, InputRegistry},
+    App,
 };
 
 impl From<&Severity> for Level {
@@ -141,22 +141,10 @@ pub(crate) fn render_findings(app: &App, registry: &InputRegistry, findings: &Fi
         println!(
             "{nunknown} unknown, {ninformational} informational, {nlow} low, {nmedium} medium, {nhigh} high",
             nunknown = findings_by_severity.get(&Severity::Unknown).unwrap_or(&0),
-            ninformational = findings_by_severity
-                .get(&Severity::Informational)
-                .unwrap_or(&0)
-                .purple(),
-            nlow = findings_by_severity
-                .get(&Severity::Low)
-                .unwrap_or(&0)
-                .cyan(),
-            nmedium = findings_by_severity
-                .get(&Severity::Medium)
-                .unwrap_or(&0)
-                .yellow(),
-            nhigh = findings_by_severity
-                .get(&Severity::High)
-                .unwrap_or(&0)
-                .red(),
+            ninformational = findings_by_severity.get(&Severity::Informational).unwrap_or(&0).purple(),
+            nlow = findings_by_severity.get(&Severity::Low).unwrap_or(&0).cyan(),
+            nmedium = findings_by_severity.get(&Severity::Medium).unwrap_or(&0).yellow(),
+            nhigh = findings_by_severity.get(&Severity::High).unwrap_or(&0).red(),
         );
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,11 +2,11 @@
 
 use std::path::PathBuf;
 
-use etcetera::{AppStrategy, AppStrategyArgs, choose_app_strategy};
+use etcetera::{choose_app_strategy, AppStrategy, AppStrategyArgs};
 
 use crate::{
-    App,
     github_api::{Client, GitHubHost},
+    App,
 };
 
 #[derive(Clone)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,8 +4,8 @@ use std::ops::Range;
 
 use camino::Utf8Path;
 use github_actions_models::common::{
-    Env,
     expr::{ExplicitExpr, LoE},
+    Env,
 };
 
 /// Convenience trait for inline transformations of `Self`.

--- a/tests/snapshot.rs
+++ b/tests/snapshot.rs
@@ -98,520 +98,398 @@ fn zizmor() -> Zizmor {
 
 #[test]
 fn test_cant_retrieve() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .output(OutputMode::Stderr)
-            .offline(true)
-            .unsetenv("GH_TOKEN")
-            .args(["pypa/sampleproject"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .output(OutputMode::Stderr)
+        .offline(true)
+        .unsetenv("GH_TOKEN")
+        .args(["pypa/sampleproject"])
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn test_invalid_inputs() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .output(OutputMode::Stderr)
-            .offline(true)
-            .workflow(workflow_under_test("invalid/invalid-workflow.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .output(OutputMode::Stderr)
+        .offline(true)
+        .workflow(workflow_under_test("invalid/invalid-workflow.yml"))
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn artipacked() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("artipacked.yml"))
-            .args(["--persona=pedantic"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("artipacked.yml"))
+        .args(["--persona=pedantic"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("artipacked.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("artipacked.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("artipacked.yml"))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("artipacked.yml"))
+        .args(["--persona=auditor"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("artipacked/issue-447-repro.yml"))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("artipacked/issue-447-repro.yml"))
+        .args(["--persona=auditor"])
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn self_hosted() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("self-hosted.yml"))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("self-hosted.yml"))
+        .args(["--persona=auditor"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("self-hosted.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("self-hosted.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "self-hosted/self-hosted-runner-label.yml"
-            ))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "self-hosted/self-hosted-runner-label.yml"
+        ))
+        .args(["--persona=auditor"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "self-hosted/self-hosted-runner-group.yml"
-            ))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "self-hosted/self-hosted-runner-group.yml"
+        ))
+        .args(["--persona=auditor"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "self-hosted/self-hosted-matrix-dimension.yml"
-            ))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "self-hosted/self-hosted-matrix-dimension.yml"
+        ))
+        .args(["--persona=auditor"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "self-hosted/self-hosted-matrix-inclusion.yml"
-            ))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "self-hosted/self-hosted-matrix-inclusion.yml"
+        ))
+        .args(["--persona=auditor"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "self-hosted/self-hosted-matrix-exclusion.yml"
-            ))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "self-hosted/self-hosted-matrix-exclusion.yml"
+        ))
+        .args(["--persona=auditor"])
+        .run()?);
 
     // Fixed regressions
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("self-hosted/issue-283-repro.yml"))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("self-hosted/issue-283-repro.yml"))
+        .args(["--persona=auditor"])
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn unpinned_uses() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("unpinned-uses.yml"))
-            .args(["--pedantic"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("unpinned-uses.yml"))
+        .args(["--pedantic"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("unpinned-uses.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("unpinned-uses.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("unpinned-uses/action.yml"))
-            .args(["--pedantic"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("unpinned-uses/action.yml"))
+        .args(["--pedantic"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("unpinned-uses/issue-433-repro.yml"))
-            .args(["--pedantic"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("unpinned-uses/issue-433-repro.yml"))
+        .args(["--pedantic"])
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn insecure_commands() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("insecure-commands.yml"))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("insecure-commands.yml"))
+        .args(["--persona=auditor"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("insecure-commands.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("insecure-commands.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("insecure-commands/action.yml"))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("insecure-commands/action.yml"))
+        .args(["--persona=auditor"])
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn template_injection() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "template-injection/template-injection-static-matrix.yml"
-            ))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "template-injection/template-injection-static-matrix.yml"
+        ))
+        .args(["--persona=auditor"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "template-injection/template-injection-dynamic-matrix.yml"
-            ))
-            .args(["--persona=auditor"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "template-injection/template-injection-dynamic-matrix.yml"
+        ))
+        .args(["--persona=auditor"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("template-injection/issue-22-repro.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("template-injection/issue-22-repro.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("template-injection/pr-317-repro.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("template-injection/pr-317-repro.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("template-injection/static-env.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("template-injection/static-env.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "template-injection/issue-339-repro.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "template-injection/issue-339-repro.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "template-injection/issue-418-repro.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "template-injection/issue-418-repro.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "template-injection/pr-425-backstop/action.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "template-injection/pr-425-backstop/action.yml"
+        ))
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn cache_poisoning() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "cache-poisoning/caching-disabled-by-default.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/caching-disabled-by-default.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "cache-poisoning/caching-enabled-by-default.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/caching-enabled-by-default.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "cache-poisoning/caching-opt-in-boolean-toggle.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/caching-opt-in-boolean-toggle.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "cache-poisoning/caching-opt-in-expression.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/caching-opt-in-expression.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "cache-poisoning/caching-opt-in-multi-value-toggle.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/caching-opt-in-multi-value-toggle.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("cache-poisoning/caching-opt-out.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("cache-poisoning/caching-opt-out.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "cache-poisoning/no-cache-aware-steps.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/no-cache-aware-steps.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "cache-poisoning/workflow-tag-trigger.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/workflow-tag-trigger.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "cache-poisoning/caching-opt-in-boolish-toggle.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/caching-opt-in-boolish-toggle.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("cache-poisoning/publisher-step.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("cache-poisoning/publisher-step.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("cache-poisoning/issue-343-repro.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("cache-poisoning/issue-343-repro.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "cache-poisoning/caching-not-configurable.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/caching-not-configurable.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "cache-poisoning/workflow-release-branch-trigger.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "cache-poisoning/workflow-release-branch-trigger.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("cache-poisoning/issue-378-repro.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("cache-poisoning/issue-378-repro.yml"))
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn excessive_permissions() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/issue-336-repro.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/issue-336-repro.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/issue-336-repro.yml"
-            ))
-            .args(["--pedantic"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/issue-336-repro.yml"
+        ))
+        .args(["--pedantic"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/workflow-default-perms.yml"
-            ))
-            .args(["--pedantic"])
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-default-perms.yml"
+        ))
+        .args(["--pedantic"])
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/workflow-read-all.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-read-all.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/workflow-write-all.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-write-all.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/workflow-empty-perms.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-empty-perms.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/jobs-broaden-permissions.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/jobs-broaden-permissions.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/workflow-write-explicit.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-write-explicit.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/workflow-default-perms-all-jobs-explicit.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/workflow-default-perms-all-jobs-explicit.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/issue-472-repro.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/issue-472-repro.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/reusable-workflow-call.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/reusable-workflow-call.yml"
+        ))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test(
-                "excessive-permissions/reusable-workflow-other-triggers.yml"
-            ))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test(
+            "excessive-permissions/reusable-workflow-other-triggers.yml"
+        ))
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn github_env() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("github-env/action.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("github-env/action.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("github-env/github-path.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("github-env/github-path.yml"))
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("github-env/issue-397-repro.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("github-env/issue-397-repro.yml"))
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn secrets_inherit() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("secrets-inherit.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("secrets-inherit.yml"))
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn bot_conditions() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("bot-conditions.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("bot-conditions.yml"))
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn overprovisioned_secrets() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("overprovisioned-secrets.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("overprovisioned-secrets.yml"))
+        .run()?);
 
     Ok(())
 }
@@ -619,30 +497,24 @@ fn overprovisioned_secrets() -> Result<()> {
 #[cfg_attr(not(feature = "gh-token-tests"), ignore)]
 #[test]
 fn ref_confusion() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("ref-confusion.yml"))
-            .offline(false)
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("ref-confusion.yml"))
+        .offline(false)
+        .run()?);
 
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("ref-confusion/issue-518-repro.yml"))
-            .offline(false)
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("ref-confusion/issue-518-repro.yml"))
+        .offline(false)
+        .run()?);
 
     Ok(())
 }
 
 #[test]
 fn unredacted_secrets() -> Result<()> {
-    insta::assert_snapshot!(
-        zizmor()
-            .workflow(workflow_under_test("unredacted-secrets.yml"))
-            .run()?
-    );
+    insta::assert_snapshot!(zizmor()
+        .workflow(workflow_under_test("unredacted-secrets.yml"))
+        .run()?);
 
     Ok(())
 }


### PR DESCRIPTION
We can't upgrade to the 2024 edition until some kinks with `maturin-action` get sorted out; see https://github.com/PyO3/maturin-action/issues/324.

This reverts commit afc2f9348beb89c9629fbff72fabe1ba3b2d24da.