### PR TITLE
bugfix: bump github-actions-models to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "github-actions-models"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d33cc977e9aaa73b0e447c5c387e1720dcdfbc54e7f86e32c76e2a78bfcb9c"
+checksum = "63a17952a0374993a4c7f8df12bd75b3d1ed8fb9c78e8dbaa32cf451143faaaa"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ clap-verbosity-flag = { version = "3.0.2", features = [
 ], default-features = false }
 etcetera = "0.8.0"
 flate2 = "1.1.0"
-github-actions-models = "0.25.0"
+github-actions-models = "0.26.0"
 http-cache-reqwest = "0.15.1"
 human-panic = "2.0.1"
 indexmap = "2.7.1"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -26,6 +26,12 @@ of `zizmor`.
 * The [bot-conditions] audit now detects `github.triggering_actor`
   as another spoofable actor check (#559)
 
+### Bug Fixes 🐛
+
+* Fixed a bug where `zizmor` would fail to parse workflows with
+  `workflow_dispatch` triggers that contained non-string inputs
+  (#563)
+
 ### Upcoming Changes 🚧
 
 * The next minor release of `zizmor` will be built with


### PR DESCRIPTION
This bumps to the latest `github-actions-models`, which fixes a parse failure on workflows that have `workflow_dispatch` triggers with non-string inputs.

Fixes #562.