### PR TITLE
bugfix: fix audit id for unredacted secrets audit

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,11 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Bug Fixes 🐛
+
+* Findings produced by ([unredacted-secrets]) now use the correct ID and
+  link to the correct URL in the audit documentation (#566)
+
 ## v1.4.0
 
 This release comes with one new audit ([unredacted-secrets]), plus a handful

--- a/src/audit/unredacted_secrets.rs
+++ b/src/audit/unredacted_secrets.rs
@@ -9,7 +9,11 @@ use super::{audit_meta, Audit};
 
 pub(crate) struct UnredactedSecrets;
 
-audit_meta!(UnredactedSecrets, "secret-leakage", "leaked secret values");
+audit_meta!(
+    UnredactedSecrets,
+    "unredacted-secrets",
+    "leaked secret values"
+);
 
 impl Audit for UnredactedSecrets {
     fn new(_: crate::AuditState) -> anyhow::Result<Self>

--- a/tests/snapshots/snapshot__unredacted_secrets.snap
+++ b/tests/snapshots/snapshot__unredacted_secrets.snap
@@ -1,9 +1,8 @@
 ---
 source: tests/snapshot.rs
 expression: "zizmor().workflow(workflow_under_test(\"unredacted-secrets.yml\")).run()?"
-snapshot_kind: text
 ---
-warning[secret-leakage]: leaked secret values
+warning[unredacted-secrets]: leaked secret values
   --> @@INPUT@@:14:18
    |
 14 |           stuff: ${{ fromJSON(secrets.password) }}
@@ -11,7 +10,7 @@ warning[secret-leakage]: leaked secret values
    |
    = note: audit confidence → High
 
-warning[secret-leakage]: leaked secret values
+warning[unredacted-secrets]: leaked secret values
   --> @@INPUT@@:17:23
    |
 17 |           otherstuff: ${{ fromJson(secrets.otherstuff).field }}


### PR DESCRIPTION
Didn't catch this with the 1.4.0 release.