### PR TITLE
bugfix: don't remove prefixes from local paths

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,12 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Bug Fixes 🐛
+
+* Fixed `zizmor`'s path presentation behavior to correctly present
+  unambiguous paths in both SARIF and "plain" outputs when
+  multiple input directories are given (#572)
+
 ## v1.4.1
 
 This is a small corrective release for v1.4.0.

--- a/src/main.rs
+++ b/src/main.rs
@@ -413,7 +413,7 @@ fn run() -> Result<ExitCode> {
             }
             tracing::info!(
                 "🌈 completed {input}",
-                input = input.key().best_effort_relative_path()
+                input = input.key().presentation_path()
             );
         }
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -105,7 +105,7 @@ impl Workflow {
             InputKey::Local(_) => None,
             InputKey::Remote(_) => {
                 // NOTE: InputKey's Display produces a URL, hence `key.to_string()`.
-                Some(Link::new(key.best_effort_relative_path(), &key.to_string()).to_string())
+                Some(Link::new(key.presentation_path(), &key.to_string()).to_string())
             }
         };
 
@@ -757,7 +757,7 @@ impl Action {
             InputKey::Local(_) => None,
             InputKey::Remote(_) => {
                 // NOTE: InputKey's Display produces a URL, hence `key.to_string()`.
-                Some(Link::new(key.best_effort_relative_path(), &key.to_string()).to_string())
+                Some(Link::new(key.presentation_path(), &key.to_string()).to_string())
             }
         };
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -90,18 +90,13 @@ impl InputKey {
         }))
     }
 
-    /// Return a "best-effort" relative path for this [`InputKey`].
+    /// Return a "presentation" path for this [`InputKey`].
     ///
     /// This will always be a relative path for remote keys,
-    /// and will be a "best-effort" relative path for local keys.
-    pub(crate) fn best_effort_relative_path(&self) -> &str {
+    /// and will be the given path for local keys.
+    pub(crate) fn presentation_path(&self) -> &str {
         match self {
-            InputKey::Local(local) => local
-                .prefix
-                .as_ref()
-                .and_then(|pfx| local.given_path.strip_prefix(pfx).ok())
-                .unwrap_or_else(|| &local.given_path)
-                .as_str(),
+            InputKey::Local(local) => local.given_path.as_str(),
             InputKey::Remote(remote) => remote.path.as_str(),
         }
     }
@@ -330,13 +325,13 @@ mod tests {
     #[test]
     fn test_input_key_local_path() {
         let local = InputKey::local("/foo/bar/baz.yml", None).unwrap();
-        assert_eq!(local.best_effort_relative_path(), "/foo/bar/baz.yml");
+        assert_eq!(local.presentation_path(), "/foo/bar/baz.yml");
 
         let local = InputKey::local("/foo/bar/baz.yml", Some("/foo")).unwrap();
-        assert_eq!(local.best_effort_relative_path(), "bar/baz.yml");
+        assert_eq!(local.presentation_path(), "/foo/bar/baz.yml");
 
         let local = InputKey::local("/foo/bar/baz.yml", Some("/foo/bar/")).unwrap();
-        assert_eq!(local.best_effort_relative_path(), "baz.yml");
+        assert_eq!(local.presentation_path(), "/foo/bar/baz.yml");
 
         let local = InputKey::local(
             "/home/runner/work/repo/repo/.github/workflows/baz.yml",
@@ -344,8 +339,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            local.best_effort_relative_path(),
-            ".github/workflows/baz.yml"
+            local.presentation_path(),
+            "/home/runner/work/repo/repo/.github/workflows/baz.yml"
         );
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -51,11 +51,7 @@ pub(crate) fn finding_snippet<'w>(
             Snippet::source(input.document().source())
                 .fold(true)
                 .line_start(1)
-                .origin(
-                    input
-                        .link()
-                        .unwrap_or(input_key.best_effort_relative_path()),
-                )
+                .origin(input.link().unwrap_or(input_key.presentation_path()))
                 .annotations(locations.iter().map(|loc| {
                     let annotation = match loc.symbolic.link {
                         Some(ref link) => link,

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -145,7 +145,7 @@ fn build_locations<'a>(locations: impl Iterator<Item = &'a Location<'a>>) -> Vec
                         .artifact_location(
                             ArtifactLocation::builder()
                                 .uri_base_id("%SRCROOT%")
-                                .uri(location.symbolic.key.best_effort_relative_path())
+                                .uri(location.symbolic.key.presentation_path())
                                 .build(),
                         )
                         .region(


### PR DESCRIPTION
Tried this on some local directories (multiple at a time) and got reasonable outputs that were unambiguous.

Fixes #571.

h/t @alex