### PR TITLE
feat: detect overprovisioned `secrets[...]`

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,11 @@ of `zizmor`.
   unambiguous paths in both SARIF and "plain" outputs when
   multiple input directories are given (#572)
 
+### Enhancements 🌱
+
+* The [overprovisioned-secrets] audit now detects indexing operations
+  on the `secrets` context that result in overprovisioning (#573)
+
 ## v1.4.1
 
 This is a small corrective release for v1.4.0.
@@ -99,7 +104,7 @@ audit results.
 
 * `zizmor` produces slightly more informative error messages when given
   an invalid input file (#482)
-* Case insensitivity in contexts is now handeled more consistently
+* Case insensitivity in contexts is now handled more consistently
   and pervasively (#491)
 
 ### Bug Fixes 🐛

--- a/src/audit/overprovisioned_secrets.rs
+++ b/src/audit/overprovisioned_secrets.rs
@@ -78,7 +78,7 @@ impl OverprovisionedSecrets {
             }
             Expr::Index(expr) => results.extend(Self::secrets_expansions(expr)),
             Expr::Context(ctx) => {
-                match (ctx.components().get(0), ctx.components().get(1)) {
+                match (ctx.components().first(), ctx.components().get(1)) {
                     // Look for `secrets[...]` accesses where the index component
                     // is not a string literal.
                     (Some(Expr::Identifier(ident)), Some(Expr::Index(idx)))

--- a/src/audit/overprovisioned_secrets.rs
+++ b/src/audit/overprovisioned_secrets.rs
@@ -1,5 +1,5 @@
 use crate::{
-    expr::{Context, Expr},
+    expr::Expr,
     finding::{Confidence, Feature, Location, Severity},
     utils::extract_expressions,
 };
@@ -77,8 +77,17 @@ impl OverprovisionedSecrets {
                 }
             }
             Expr::Index(expr) => results.extend(Self::secrets_expansions(expr)),
-            Expr::Context(Context { raw: _, components }) => {
-                results.extend(components.iter().flat_map(Self::secrets_expansions))
+            Expr::Context(ctx) => {
+                match (ctx.components().get(0), ctx.components().get(1)) {
+                    // Look for `secrets[...]` accesses where the index component
+                    // is not a string literal.
+                    (Some(Expr::Identifier(ident)), Some(Expr::Index(idx)))
+                        if ident == "secrets" && !matches!(idx.as_ref(), Expr::String(_)) =>
+                    {
+                        results.push(())
+                    }
+                    _ => results.extend(ctx.components.iter().flat_map(Self::secrets_expansions)),
+                }
             }
             Expr::BinOp { lhs, op: _, rhs } => {
                 results.extend(Self::secrets_expansions(lhs));
@@ -106,6 +115,10 @@ mod tests {
             ("false || toJSON(secrets)", 1),
             ("toJSON(secrets) || toJSON(secrets)", 2),
             ("format('{0}', toJSON(secrets))", 1),
+            ("secrets[format('GH_PAT_%s', matrix.env)]", 1),
+            ("SECRETS[format('GH_PAT_%s', matrix.env)]", 1),
+            ("SECRETS[something.else]", 1),
+            ("SECRETS['literal']", 0),
         ] {
             let expr = crate::expr::Expr::parse(expr).unwrap();
             assert_eq!(


### PR DESCRIPTION
This detects patterns like `secrets[...]` where `...` is not a string literal, since these are similar to `toJSON(secrets)` in that they cause the entire context to be injected into the runner.

Closes #551.