### PR TITLE
fix: respect `include-hidden-files` in actions/upload-artifact v4.4+

### DIFF
--- a/src/audit/artipacked.rs
+++ b/src/audit/artipacked.rs
@@ -86,6 +86,13 @@ impl Audit for Artipacked {
                     continue;
                 };
 
+                if with
+                    .get("include-hidden-files")
+                    .map_or(false, |v| v.to_string() == "false")
+                {
+                    continue;
+                }
+
                 let dangerous_paths = self.dangerous_artifact_patterns(path);
                 if !dangerous_paths.is_empty() {
                     // TODO: plumb dangerous_paths into the annotation here.


### PR DESCRIPTION
Added a check for the `include-hidden-files` (defaults to `false`) configuration of `actions/upload-artifact` (Added in `v4.4.0` https://github.com/actions/upload-artifact/pull/598).

If a workflow uses `actions/upload-artifact@v4`,  the artifact no longer includes hidden files (e.g. `.git/`), meaning even if the `actions/checkout`'s `persistent-credentials` is not set or configured `true`,  the credentials will not be packed and uploaded. 

As far as I understand, `zizmor` can't apply policies based on the actions' references (commit hashes or tags).
For steps that uses `v3` or earlier, there may be false positives; however, as officially announced, it was deprecated last year:

https://github.com/actions/upload-artifact/blob/4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1/README.md?plain=1#L4

