### PR TITLE
ci: pypi: bump maturin-action to v1.47.2

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build wheels
-        uses: PyO3/maturin-action@49453e0a6599125b2698abe070e181399fbcc9ab # v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
@@ -70,7 +70,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build wheels
-        uses: PyO3/maturin-action@49453e0a6599125b2698abe070e181399fbcc9ab # v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
@@ -96,7 +96,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build wheels
-        uses: PyO3/maturin-action@49453e0a6599125b2698abe070e181399fbcc9ab # v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
@@ -121,7 +121,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build wheels
-        uses: PyO3/maturin-action@49453e0a6599125b2698abe070e181399fbcc9ab # v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
@@ -139,7 +139,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build sdist
-        uses: PyO3/maturin-action@49453e0a6599125b2698abe070e181399fbcc9ab # v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           command: sdist
           args: --out dist
@@ -172,7 +172,7 @@ jobs:
           subject-path: 'wheels-*/*'
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        uses: PyO3/maturin-action@49453e0a6599125b2698abe070e181399fbcc9ab # v1
+        uses: PyO3/maturin-action@36db84001d74475ad1b8e6613557ae4ee2dc3598 # v1
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
See: https://github.com/PyO3/maturin-action/releases/tag/v1.47.2

See: https://github.com/PyO3/maturin-action/pull/330