### PR TITLE
cli: re-add `--no-progress` flag

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,8 @@ of `zizmor`.
   user expectation. Users who wish to explicitly collect everything
   regardless of ignore patterns can continue to use `--collect=all`
   (#575)
+* `zizmor` now has a `--no-progress` flag that disables
+  progress bars, even if the terminal supports them (#589)
 
 ### Bug Fixes 🐛
 

--- a/docs/snippets/help.txt
+++ b/docs/snippets/help.txt
@@ -22,6 +22,8 @@ Options:
           Increase logging verbosity
   -q, --quiet...
           Decrease logging verbosity
+      --no-progress
+          Don't show progress bars, even if the terminal supports them
       --format <FORMAT>
           The output format to emit. By default, plain text will be emitted [default: plain] [possible values: plain, json, sarif]
   -c, --config <CONFIG>


### PR DESCRIPTION
This was removed in 0.9.0 with the `tracing_indicatif` refactor, but I'm realizing that it's useful to have regardless.

In particular, this will help users in contexts where their integration *is* (or pretends to be) a terminal, but that terminal doesn't support interactive behaviors like progress bars. In particular, users of `pre-commit.ci` will be able to use this to prevent the progress bar from spamming their outputs.

See https://github.com/woodruffw/zizmor/issues/582.