### PR TITLE
bugfix: don't require `.git/` to respect `.gitignore` files

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,11 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Bug Fixes 🐛
+
+* Fixed a bug where `zizmor` would fail to honor `.gitignore` files
+  when a `.git/` directory is not present (#598)
+
 ## v1.5.0
 
 ### New Features 🌈

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,8 +245,19 @@ fn collect_from_dir(
     // explicitly enable it. This also enables filtering by a global
     // `.gitignore` file and the `.git/info/exclude` file, since these
     // typically align with the user's expectations.
+    //
+    // We honor `.gitignore` and similar files even if `.git/` is not
+    // present, since users may retrieve or reconstruct a source archive
+    // without a `.git/` directory. In particular, this snares some
+    // zizmor integrators.
+    //
+    // See: https://github.com/woodruffw/zizmor/issues/596
     if mode.respects_gitignore() {
-        walker.git_ignore(true).git_global(true).git_exclude(true);
+        walker
+            .require_git(false)
+            .git_ignore(true)
+            .git_global(true)
+            .git_exclude(true);
     }
 
     for entry in walker.build() {


### PR DESCRIPTION
Fixes #596.