### PR TITLE
ci: pypi: bump to macos-14

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -114,9 +114,9 @@ jobs:
         platform:
           # TODO: Bump to macos-15 once Rust 1.85+ is available.
           # See: https://github.com/actions/runner-images/issues/11637
-          - runner: macos-13
+          - runner: macos-14
             target: x86_64
-          - runner: macos-13
+          - runner: macos-14
             target: aarch64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
The wheels of justice turn slowly, but grind exceedingly fine.

See: https://github.com/actions/runner-images/issues/11637#issuecomment-2720420481