### PR TITLE
ci: pypi: use manylinux_2_28 consistently

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,19 +22,19 @@ jobs:
             manylinux: "2_28"
           - runner: ubuntu-24.04
             target: x86
-            manylinux: "auto"
+            manylinux: "2_28"
           - runner: ubuntu-24.04
             target: aarch64
             manylinux: "2_24"
           - runner: ubuntu-24.04
             target: armv7
-            manylinux: "auto"
+            manylinux: "2_28"
           - runner: ubuntu-24.04
             target: s390x
-            manylinux: "auto"
+            manylinux: "2_28"
           - runner: ubuntu-24.04
             target: ppc64le
-            manylinux: "auto"
+            manylinux: "2_28"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,7 +19,7 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: x86_64
-            manylinux: "2_24"
+            manylinux: "2_28"
             before-script: python3 -m ensurepip
           - runner: ubuntu-24.04
             target: x86

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,22 +19,22 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: x86_64
-            manylinux: auto
+            manylinux: "2_28"
           - runner: ubuntu-24.04
             target: x86
-            manylinux: auto
+            manylinux: "2_28"
           - runner: ubuntu-24.04
             target: aarch64
-            manylinux: "2_24"
+            manylinux: "2_28"
           - runner: ubuntu-24.04
             target: armv7
-            manylinux: auto
+            manylinux: "2_28"
           - runner: ubuntu-24.04
             target: s390x
-            manylinux: auto
+            manylinux: "2_28"
           - runner: ubuntu-24.04
             target: ppc64le
-            manylinux: auto
+            manylinux: "2_28"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -25,7 +25,7 @@ jobs:
             manylinux: "2_28"
           - runner: ubuntu-24.04
             target: aarch64
-            manylinux: "2_28"
+            manylinux: "2_24"
           - runner: ubuntu-24.04
             target: armv7
             manylinux: "2_28"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -31,10 +31,10 @@ jobs:
             manylinux: "2_28"
           - runner: ubuntu-24.04
             target: s390x
-            manylinux: "2_28"
+            manylinux: "auto"
           - runner: ubuntu-24.04
             target: ppc64le
-            manylinux: "2_28"
+            manylinux: "auto"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -46,7 +46,7 @@ jobs:
           args: --release --out dist
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }} # zizmor: ignore[cache-poisoning]
           manylinux: ${{ matrix.platform.manylinux }}
-          before-script-linux: python3 -m ensurepip
+          before-script-linux: ${{ matrix.platform.manylinux == '2_28' && 'python3 -m ensurepip' || 'true'}}
       - name: Upload wheels
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,9 +19,7 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: x86_64
-            manylinux: "auto"
-            # https://github.com/tree-sitter/tree-sitter/issues/4186
-            docker-options: -e CFLAGS="-D_BSD_SOURCE"
+            manylinux: "2_24"
           - runner: ubuntu-24.04
             target: x86
             manylinux: "auto"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,7 +20,6 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64
             manylinux: "2_28"
-            before-script: python3 -m ensurepip
           - runner: ubuntu-24.04
             target: x86
             manylinux: "auto"
@@ -45,9 +44,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }} # zizmor: ignore[cache-poisoning]
           manylinux: ${{ matrix.platform.manylinux }}
-          before-script-linux: ${{ matrix.platform.before-script }}
       - name: Upload wheels
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
@@ -76,7 +73,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }} # zizmor: ignore[cache-poisoning]
           manylinux: musllinux_1_2
       - name: Upload wheels
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
@@ -102,7 +98,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }} # zizmor: ignore[cache-poisoning]
       - name: Upload wheels
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
@@ -129,7 +124,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
-          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }} # zizmor: ignore[cache-poisoning]
       - name: Upload wheels
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,21 +20,21 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64
             manylinux: "2_28"
-          - runner: ubuntu-24.04
-            target: x86
-            manylinux: "2_28"
+          # - runner: ubuntu-24.04
+          #   target: x86
+          #   manylinux: "auto"
           - runner: ubuntu-24.04
             target: aarch64
             manylinux: "2_24"
           - runner: ubuntu-24.04
             target: armv7
             manylinux: "2_28"
-          - runner: ubuntu-24.04
-            target: s390x
-            manylinux: "2_28"
-          - runner: ubuntu-24.04
-            target: ppc64le
-            manylinux: "2_28"
+          # - runner: ubuntu-24.04
+          #   target: s390x
+          #   manylinux: "2_28"
+          # - runner: ubuntu-24.04
+          #   target: ppc64le
+          #   manylinux: "2_28"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -58,8 +58,8 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: x86_64
-          - runner: ubuntu-24.04
-            target: x86
+          # - runner: ubuntu-24.04
+          #   target: x86
           - runner: ubuntu-24.04
             target: aarch64
           - runner: ubuntu-24.04

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -46,6 +46,7 @@ jobs:
           args: --release --out dist
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }} # zizmor: ignore[cache-poisoning]
           manylinux: ${{ matrix.platform.manylinux }}
+          before-script-linux: python3 -m ensurepip
       - name: Upload wheels
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -28,7 +28,7 @@ jobs:
             manylinux: "2_24"
           - runner: ubuntu-24.04
             target: armv7
-            manylinux: "2_28"
+            manylinux: "auto"
           - runner: ubuntu-24.04
             target: s390x
             manylinux: "auto"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,10 +19,12 @@ jobs:
         platform:
           - runner: ubuntu-24.04
             target: x86_64
-            manylinux: "2_28"
+            manylinux: "auto"
+            # https://github.com/tree-sitter/tree-sitter/issues/4186
+            docker-options: -e CPPFLAGS="-D_BSD_SOURCE"
           - runner: ubuntu-24.04
             target: x86
-            manylinux: "2_28"
+            manylinux: "auto"
           - runner: ubuntu-24.04
             target: aarch64
             manylinux: "2_24"
@@ -46,7 +48,7 @@ jobs:
           args: --release --out dist
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }} # zizmor: ignore[cache-poisoning]
           manylinux: ${{ matrix.platform.manylinux }}
-          before-script-linux: ${{ matrix.platform.manylinux == '2_28' && 'python3 -m ensurepip' || 'true'}}
+          docker-options: ${{ matrix.platform.docker-options }}
       - name: Upload wheels
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -21,7 +21,7 @@ jobs:
             target: x86_64
             manylinux: "auto"
             # https://github.com/tree-sitter/tree-sitter/issues/4186
-            docker-options: -e CPPFLAGS="-D_BSD_SOURCE"
+            docker-options: -e CFLAGS="-D_BSD_SOURCE"
           - runner: ubuntu-24.04
             target: x86
             manylinux: "auto"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -20,6 +20,7 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64
             manylinux: "2_24"
+            before-script: python3 -m ensurepip
           - runner: ubuntu-24.04
             target: x86
             manylinux: "auto"
@@ -46,7 +47,7 @@ jobs:
           args: --release --out dist
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }} # zizmor: ignore[cache-poisoning]
           manylinux: ${{ matrix.platform.manylinux }}
-          docker-options: ${{ matrix.platform.docker-options }}
+          before-script-linux: ${{ matrix.platform.before-script }}
       - name: Upload wheels
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,7 +33,13 @@ description: Installation instructions for zizmor.
     ![PyPI - Version](https://img.shields.io/pypi/v/zizmor)
 
     `zizmor` is available on [PyPI](https://pypi.org) and can be installed
-    with any Python package installer:
+    with any Python package installer.
+
+    !!! important
+
+        Python wheels for `zizmor` are provided on a best-effort basis,
+        with priority given to the most common architectures and host OSes.
+
 
     ```bash
     # with pip

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,6 +14,14 @@ of `zizmor`.
 * Fixed a bug where `zizmor` would over-eagerly parse invalid and
   commented-out expressions, resulting in spurious warnings (#570)
 
+### Upcoming Changes 🚧
+
+* The official [PyPI builds](./installation.md/#pypi) for `zizmor`
+  will support fewer architectures in the next release, due to
+  cross-compilation and testing difficulties. This should have
+  **no effect** on the overwhelming majority of users.
+  See #603 for additional details.
+
 ## v1.5.1
 
 ### Bug Fixes 🐛


### PR DESCRIPTION
Using auto causes us to default to exceptionally
old versions of glibc, along with containers that
struggle badly to build things like tree-sitter.

See: https://github.com/tree-sitter/tree-sitter/issues/4186

See: https://github.com/tree-sitter/tree-sitter/issues/4271