### PR TITLE
chore: drop explicit dependency on streaming-iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,7 +3166,6 @@ dependencies = [
  "serde_json",
  "serde_json_path",
  "serde_yaml",
- "streaming-iterator",
  "tar",
  "terminal-link",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,6 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde-sarif = "0.7.0"
 serde_json = "1.0.140"
 serde_yaml = "0.9.34"
-# TODO remove pending https://github.com/tree-sitter/tree-sitter/pull/4034
-streaming-iterator = "0.1.9"
 tar = "0.4.44"
 terminal-link = "0.1.0"
 tokio = { version = "1.44.0", features = ["rt-multi-thread"] }

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -6,8 +6,9 @@ use anyhow::{Context, Result};
 use github_actions_models::action;
 use github_actions_models::workflow::job::StepBody;
 use regex::Regex;
-use streaming_iterator::StreamingIterator;
-use tree_sitter::{Language, Parser, Query, QueryCapture, QueryCursor, QueryMatches, Tree};
+use tree_sitter::{
+    Language, Parser, Query, QueryCapture, QueryCursor, QueryMatches, StreamingIterator as _, Tree,
+};
 
 use super::{Audit, audit_meta};
 use crate::finding::{Confidence, Finding, Severity};


### PR DESCRIPTION
Handled implicitly via tree-sitter now.