### PR TITLE
Clearly state that `actions: read` is only required for private repos

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -404,9 +404,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      # required for workflows in private repositories
-      contents: read
-      actions: read
+      contents: read # only required for workflows in private repositories
+      actions: read # only required for workflows in private repositories
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -404,8 +404,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      contents: read # only required for workflows in private repositories
-      actions: read # only required for workflows in private repositories
+      contents: read # only needed for private repos
+      actions: read # only needed for private repos
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
fix #608