### PR TITLE
bugfix: sarif: add working directory to invocation

### DIFF
--- a/.github/workflows/test-sarif.yml
+++ b/.github/workflows/test-sarif.yml
@@ -30,4 +30,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
         with:
           sarif_file: results.sarif
-          category: zizmor
+          category: zizmor-test-sarif-presentation

--- a/.github/workflows/test-sarif.yml
+++ b/.github/workflows/test-sarif.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'test-sarif-presentation')
     permissions:
-      issues: write # for 'Leave comment' step
+      pull-requests: write # for 'Leave comment' step
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/test-sarif.yml
+++ b/.github/workflows/test-sarif.yml
@@ -14,6 +14,8 @@ jobs:
   test-sarif-presentation:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'test-sarif-presentation')
+    permissions:
+      issues: write # for 'Leave comment' step
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -31,3 +33,16 @@ jobs:
         with:
           sarif_file: results.sarif
           category: zizmor-test-sarif-presentation
+
+      - name: Leave comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            let url = `https://github.com/woodruffw/zizmor/security/code-scanning?query=pr%3A${context.issue.number}+is%3Aopen+sort%3Acreated-desc`
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Presentation results: <${url}>`
+            })

--- a/.github/workflows/test-sarif.yml
+++ b/.github/workflows/test-sarif.yml
@@ -1,0 +1,33 @@
+name: Test SARIF Presentation
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
+permissions: {}
+
+jobs:
+  test-sarif-presentation:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'test-sarif-presentation')
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+
+      - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2
+
+      - name: Run zizmor
+        run: |
+          cargo run -- --format sarif . > results.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@6bb031afdd8eb862ea3fc1848194185e076637e5 # v3.28.11
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/test-sarif.yml
+++ b/.github/workflows/test-sarif.yml
@@ -44,5 +44,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Presentation results: <${url}>`
+              body: `:robot: Presentation results: <${url}>`
             })

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,8 @@ of `zizmor`.
   commented-out expressions, resulting in spurious warnings (#570)
 * Fixed a bug where `zizmor` would fail to honor `# zizmor: ignore[rule]`
   comments in unintuitive cases (#612)
+* Fixed a regression in `zizmor`'s SARIF output format that caused suboptimal
+  presentation of findings on GitHub (#621)
 
 ### Upcoming Changes 🚧
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -536,14 +536,7 @@ fn run() -> Result<ExitCode> {
         OutputFormat::Plain => render::render_findings(&app, &registry, &results),
         OutputFormat::Json => serde_json::to_writer_pretty(stdout(), &results.findings())?,
         OutputFormat::Sarif => {
-            // HACK(ww): GitHub's SARIF feature claims to support relative paths
-            // in results, but can't handle paths like `./foo/bar`.
-            // See further comments in sarif.rs for how we work around this
-            // using the passed-in $CWD.
-            let cwd = Utf8PathBuf::try_from(
-                std::env::current_dir().with_context(|| "couldn't access CWD")?,
-            )?;
-            serde_json::to_writer_pretty(stdout(), &sarif::build(results.findings(), &cwd))?
+            serde_json::to_writer_pretty(stdout(), &sarif::build(results.findings()))?
         }
     };
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -94,10 +94,15 @@ impl InputKey {
         }))
     }
 
-    pub(crate) fn sarif_path(&self) -> String {
+    pub(crate) fn sarif_path(&self) -> &str {
         match self {
-            InputKey::Local(local) => local.given_path.canonicalize_utf8().unwrap().into(),
-            InputKey::Remote(_) => todo!(),
+            InputKey::Local(local) => local
+                .prefix
+                .as_ref()
+                .and_then(|pfx| local.given_path.strip_prefix(pfx).ok())
+                .unwrap_or_else(|| &local.given_path)
+                .as_str(),
+            InputKey::Remote(remote) => remote.path.as_str(),
         }
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -94,6 +94,13 @@ impl InputKey {
         }))
     }
 
+    pub(crate) fn sarif_path(&self) -> String {
+        match self {
+            InputKey::Local(local) => local.given_path.canonicalize_utf8().unwrap().into(),
+            InputKey::Remote(_) => todo!(),
+        }
+    }
+
     /// Return a "presentation" path for this [`InputKey`].
     ///
     /// This will always be a relative path for remote keys,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -94,13 +94,6 @@ impl InputKey {
         }))
     }
 
-    pub(crate) fn sarif_path(&self) -> String {
-        match self {
-            InputKey::Local(local) => local.given_path.canonicalize_utf8().unwrap().into(),
-            InputKey::Remote(_) => todo!(),
-        }
-    }
-
     /// Return a "presentation" path for this [`InputKey`].
     ///
     /// This will always be a relative path for remote keys,

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -70,11 +70,7 @@ fn build_run(findings: &[Finding], cwd: &Utf8Path) -> Run {
             // we include the `$CWD` as `invocations[0].working_directory.uri`,
             // which should make GitHub's viewer process relative paths
             // as if they were absolute.
-            .working_directory(
-                ArtifactLocation::builder()
-                    .uri(format!("file://{cwd}"))
-                    .build(),
-            )
+            .working_directory(ArtifactLocation::builder().uri(cwd).build())
             .build()])
         .build()
 }

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -70,7 +70,7 @@ fn build_run(findings: &[Finding], cwd: &Utf8Path) -> Run {
             // we include the `$CWD` as `invocations[0].working_directory.uri`,
             // which should make GitHub's viewer process relative paths
             // as if they were absolute.
-            .working_directory(ArtifactLocation::builder().uri(cwd).build())
+            .working_directory(ArtifactLocation::builder().uri(cwd.as_str()).build())
             .build()])
         .build()
 }

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -166,7 +166,7 @@ fn build_locations<'a>(locations: impl Iterator<Item = &'a Location<'a>>) -> Vec
                     PhysicalLocation::builder()
                         .artifact_location(
                             ArtifactLocation::builder()
-                                .uri_base_id("%SRCROOT%")
+                                // .uri_base_id("%SRCROOT%")
                                 .uri(location.symbolic.key.presentation_path())
                                 .build(),
                         )

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -114,7 +114,7 @@ fn build_result(finding: &Finding<'_>) -> SarifResult {
         .unwrap();
 
     SarifResult::builder()
-        .rule_id(finding.ident)
+        .rule_id(format!("zizmor/{}", finding.ident))
         // NOTE: We use the primary location's annotation for the result's message.
         // This is conceptually incorrect since the location's annotation should
         // only be on the location itself. However, GitHub's SARIF viewer does not

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -166,7 +166,7 @@ fn build_locations<'a>(locations: impl Iterator<Item = &'a Location<'a>>) -> Vec
                     PhysicalLocation::builder()
                         .artifact_location(
                             ArtifactLocation::builder()
-                                // .uri_base_id("%SRCROOT%")
+                                .uri_base_id("%SRCROOT%")
                                 .uri(location.symbolic.key.presentation_path())
                                 .build(),
                         )

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -161,7 +161,7 @@ fn build_locations<'a>(locations: impl Iterator<Item = &'a Location<'a>>) -> Vec
                         .artifact_location(
                             ArtifactLocation::builder()
                                 .uri_base_id("%SRCROOT%")
-                                .uri(location.symbolic.key.sarif_path())
+                                .uri(location.symbolic.key.presentation_path())
                                 .build(),
                         )
                         .region(

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -61,6 +61,10 @@ fn build_run(findings: &[Finding], cwd: &Utf8Path) -> Run {
                 )
                 .build(),
         )
+        // .original_uri_base_ids([(
+        //     "SRCROOT".into(),
+        //     ArtifactLocation::builder().uri(cwd.as_str()).build(),
+        // )])
         .results(build_results(findings))
         .invocations([Invocation::builder()
             // We only produce results on successful executions.
@@ -87,7 +91,7 @@ fn build_rules(findings: &[Finding]) -> Vec<ReportingDescriptor> {
 
 fn build_rule(finding: &Finding) -> ReportingDescriptor {
     ReportingDescriptor::builder()
-        .id(finding.ident)
+        .id(format!("zizmor/{}", finding.ident))
         .help_uri(finding.url)
         .help(
             MultiformatMessageString::builder()

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -165,7 +165,7 @@ fn build_locations<'a>(locations: impl Iterator<Item = &'a Location<'a>>) -> Vec
                         .artifact_location(
                             ArtifactLocation::builder()
                                 .uri_base_id("%SRCROOT%")
-                                .uri(location.symbolic.key.presentation_path())
+                                .uri(location.symbolic.key.sarif_path())
                                 .build(),
                         )
                         .region(

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -46,18 +46,12 @@ pub(crate) fn build(findings: &[Finding], cwd: &Utf8Path) -> Sarif {
 }
 
 fn build_run(findings: &[Finding], cwd: &Utf8Path) -> Run {
-    let name = if cfg!(debug_assertions) {
-        "zizmor-debug"
-    } else {
-        env!("CARGO_CRATE_NAME")
-    };
-
     Run::builder()
         .tool(
             Tool::builder()
                 .driver(
                     ToolComponent::builder()
-                        .name(name)
+                        .name(env!("CARGO_CRATE_NAME"))
                         .version(env!("CARGO_PKG_VERSION"))
                         .semantic_version(env!("CARGO_PKG_VERSION"))
                         .download_uri(env!("CARGO_PKG_REPOSITORY"))

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -47,7 +47,7 @@ pub(crate) fn build(findings: &[Finding], cwd: &Utf8Path) -> Sarif {
 
 fn build_run(findings: &[Finding], cwd: &Utf8Path) -> Run {
     let name = if cfg!(debug_assertions) {
-        "zizmor[debug]"
+        "zizmor-debug"
     } else {
         env!("CARGO_CRATE_NAME")
     };

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -74,7 +74,11 @@ fn build_run(findings: &[Finding], cwd: &Utf8Path) -> Run {
             // we include the `$CWD` as `invocations[0].working_directory.uri`,
             // which should make GitHub's viewer process relative paths
             // as if they were absolute.
-            .working_directory(ArtifactLocation::builder().uri(cwd.as_str()).build())
+            .working_directory(
+                ArtifactLocation::builder()
+                    .uri(format!("file://{cwd}"))
+                    .build(),
+            )
             .build()])
         .build()
 }

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -61,10 +61,6 @@ fn build_run(findings: &[Finding], cwd: &Utf8Path) -> Run {
                 )
                 .build(),
         )
-        // .original_uri_base_ids([(
-        //     "SRCROOT".into(),
-        //     ArtifactLocation::builder().uri(cwd.as_str()).build(),
-        // )])
         .results(build_results(findings))
         .invocations([Invocation::builder()
             // We only produce results on successful executions.
@@ -164,7 +160,6 @@ fn build_locations<'a>(locations: impl Iterator<Item = &'a Location<'a>>) -> Vec
                     PhysicalLocation::builder()
                         .artifact_location(
                             ArtifactLocation::builder()
-                                .uri_base_id("%SRCROOT%")
                                 .uri(location.symbolic.key.sarif_path())
                                 .build(),
                         )

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -80,7 +80,7 @@ fn build_rules(findings: &[Finding]) -> Vec<ReportingDescriptor> {
 
 fn build_rule(finding: &Finding) -> ReportingDescriptor {
     ReportingDescriptor::builder()
-        .id(format!("zizmor/{}", finding.ident))
+        .id(finding.ident)
         .help_uri(finding.url)
         .help(
             MultiformatMessageString::builder()
@@ -103,7 +103,7 @@ fn build_result(finding: &Finding<'_>) -> SarifResult {
         .unwrap();
 
     SarifResult::builder()
-        .rule_id(format!("zizmor/{}", finding.ident))
+        .rule_id(finding.ident)
         // NOTE: We use the primary location's annotation for the result's message.
         // This is conceptually incorrect since the location's annotation should
         // only be on the location itself. However, GitHub's SARIF viewer does not

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -46,12 +46,18 @@ pub(crate) fn build(findings: &[Finding], cwd: &Utf8Path) -> Sarif {
 }
 
 fn build_run(findings: &[Finding], cwd: &Utf8Path) -> Run {
+    let name = if cfg!(debug_assertions) {
+        "zizmor[debug]"
+    } else {
+        env!("CARGO_CRATE_NAME")
+    };
+
     Run::builder()
         .tool(
             Tool::builder()
                 .driver(
                     ToolComponent::builder()
-                        .name(env!("CARGO_CRATE_NAME"))
+                        .name(name)
                         .version(env!("CARGO_PKG_VERSION"))
                         .semantic_version(env!("CARGO_PKG_VERSION"))
                         .download_uri(env!("CARGO_PKG_REPOSITORY"))

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -161,7 +161,7 @@ fn build_locations<'a>(locations: impl Iterator<Item = &'a Location<'a>>) -> Vec
                         .artifact_location(
                             ArtifactLocation::builder()
                                 .uri_base_id("%SRCROOT%")
-                                .uri(location.symbolic.key.presentation_path())
+                                .uri(location.symbolic.key.sarif_path())
                                 .build(),
                         )
                         .region(


### PR DESCRIPTION
Fixes #604.

This performs the fix by partially reverting #572 -- the "presentation" path is still used in formats like the "plain" (cargo-style) output, but the SARIF format now uses a `sarif_path` helper that removes the input prefix (even when that input prefix is something relative that GitHub _should_ be handling correctly).

To test this, I've added a new `test-sarif` workflow that gets triggered by the `test-sarif-presentation` label -- when a PR is labeled as such, the workflow runs and uses a custom category to test any SARIF changes made. 

~~I don't have a good way to test this yet -- my initial thought was to add some kind of `issue_comment` trigger so that I could do something like `/sariftest`, but I don't really like that. Another option would be a `pull_request` with the `labeled` sub-event. Either way, the goal would be to run a separate workflow (or job) that performs the SARIF steps for testing purposes.~~