### PR TITLE
feat: attempt to mark SARIF results as security findings

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,6 +9,11 @@ of `zizmor`.
 
 ## Next (UNRELEASED)
 
+### Improvements 🌱
+
+* The SARIF output format now marks each rule as a "security" rule,
+  which helps GitHub's presentation of the results (#631)
+
 ## v1.5.2
 
 ### Bug Fixes 🐛

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 
+use serde_json::json;
 use serde_sarif::sarif::{
     ArtifactContent, ArtifactLocation, Invocation, Location as SarifLocation, LogicalLocation,
     Message, MultiformatMessageString, PhysicalLocation, PropertyBag, Region, ReportingDescriptor,
@@ -86,6 +87,15 @@ fn build_rule(finding: &Finding) -> ReportingDescriptor {
             MultiformatMessageString::builder()
                 .text(finding.desc)
                 .markdown(finding.to_markdown())
+                .build(),
+        )
+        .properties(
+            PropertyBag::builder()
+                .tags(["security".into()])
+                // NOTE: This is a dummy value; each result will have its own severity.
+                // This is needed to ensure that GitHub properly renders results
+                // as "security" findings.
+                // .additional_properties([("security-severity".into(), json!(1.0))])
                 .build(),
         )
         .build()

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashSet;
 
-use serde_json::json;
 use serde_sarif::sarif::{
     ArtifactContent, ArtifactLocation, Invocation, Location as SarifLocation, LogicalLocation,
     Message, MultiformatMessageString, PhysicalLocation, PropertyBag, Region, ReportingDescriptor,
@@ -89,15 +88,7 @@ fn build_rule(finding: &Finding) -> ReportingDescriptor {
                 .markdown(finding.to_markdown())
                 .build(),
         )
-        .properties(
-            PropertyBag::builder()
-                .tags(["security".into()])
-                // NOTE: This is a dummy value; each result will have its own severity.
-                // This is needed to ensure that GitHub properly renders results
-                // as "security" findings.
-                .additional_properties([("security-severity".into(), json!("1.0"))])
-                .build(),
-        )
+        .properties(PropertyBag::builder().tags(["security".into()]).build())
         .build()
 }
 

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -95,7 +95,7 @@ fn build_rule(finding: &Finding) -> ReportingDescriptor {
                 // NOTE: This is a dummy value; each result will have its own severity.
                 // This is needed to ensure that GitHub properly renders results
                 // as "security" findings.
-                .additional_properties([("security-severity".into(), json!(1.0))])
+                .additional_properties([("security-severity".into(), json!("1.0"))])
                 .build(),
         )
         .build()

--- a/src/sarif.rs
+++ b/src/sarif.rs
@@ -95,7 +95,7 @@ fn build_rule(finding: &Finding) -> ReportingDescriptor {
                 // NOTE: This is a dummy value; each result will have its own severity.
                 // This is needed to ensure that GitHub properly renders results
                 // as "security" findings.
-                // .additional_properties([("security-severity".into(), json!(1.0))])
+                .additional_properties([("security-severity".into(), json!(1.0))])
                 .build(),
         )
         .build()


### PR DESCRIPTION
GitHub treats rules as "non-security" by default. All `zizmor` rules are security rules, so this just marks them as such so that GitHub tags each finding/result correctly.

~~WIP.~~