### PR TITLE
feat: basic dataflow for context expansion

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,8 +13,9 @@ of `zizmor`.
 
 * The SARIF output format now marks each rule as a "security" rule,
   which helps GitHub's presentation of the results (#631)
-* The [template-injection] audit is now much performs dataflow analysis
-  to determine whether contexts actually expand in an unsafe manner (#640)
+* The [template-injection] audit is now performs dataflow analysis
+  to determine whether contexts actually expand in an unsafe manner,
+  making it significantly more accurate (#640)
 
 ### Bug Fixes 🐛
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,6 +13,8 @@ of `zizmor`.
 
 * The SARIF output format now marks each rule as a "security" rule,
   which helps GitHub's presentation of the results (#631)
+* The [template-injection] audit is now much performs dataflow analysis
+  to determine whether contexts actually expand in an unsafe manner (#640)
 
 ### Bug Fixes 🐛
 

--- a/src/audit/overprovisioned_secrets.rs
+++ b/src/audit/overprovisioned_secrets.rs
@@ -65,7 +65,7 @@ impl OverprovisionedSecrets {
                 // TODO: Consider any function call that accepts bare `secrets`
                 // to be a finding? Are there any other functions that users
                 // would plausibly call with the entire `secrets` object?
-                if func.eq_ignore_ascii_case("toJSON")
+                if func == "toJSON"
                     && args
                         .iter()
                         .any(|arg| matches!(arg, Expr::Context(ctx) if ctx == "secrets"))

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -187,7 +187,7 @@ impl TemplateInjection {
                 continue;
             }
 
-            for context in parsed.expanded_contexts() {
+            for context in parsed.dataflow_contexts() {
                 if context.child_of("secrets") {
                     // While not ideal, secret expansion is typically not exploitable.
                     continue;

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -187,7 +187,7 @@ impl TemplateInjection {
                 continue;
             }
 
-            for context in parsed.contexts() {
+            for context in parsed.expanded_contexts() {
                 if context.child_of("secrets") {
                     // While not ideal, secret expansion is typically not exploitable.
                     continue;

--- a/src/audit/unredacted_secrets.rs
+++ b/src/audit/unredacted_secrets.rs
@@ -70,7 +70,7 @@ impl UnredactedSecrets {
 
         match expr {
             Expr::Call { func, args } => {
-                if func.eq_ignore_ascii_case("fromJSON")
+                if func == "fromJSON"
                     && args
                         .iter()
                         .any(|arg| matches!(arg, Expr::Context(ctx) if ctx.child_of("secrets")))

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -200,6 +200,9 @@ impl<'src> Expr<'src> {
 
         match self {
             Expr::Call { func, args } => {
+                // These functions, when evaluated, produce an evaluation
+                // that includes some or all of the contexts listed in
+                // their arguments.
                 if func == "toJSON" || func == "format" || func == "join" {
                     for arg in args {
                         contexts.extend(arg.expanded_contexts());
@@ -214,9 +217,12 @@ impl<'src> Expr<'src> {
             // to the contents of `something.foo`.
             Expr::Context(ctx) => contexts.push(ctx),
             Expr::BinOp { lhs, op, rhs } => match op {
+                // With && only the RHS can flow into the evaluation as a context
+                // (rather than a boolean).
                 BinOp::And => {
                     contexts.extend(rhs.expanded_contexts());
                 }
+                // With || either the LHS or RHS can flow into the evaluation as a context.
                 BinOp::Or => {
                     contexts.extend(lhs.expanded_contexts());
                     contexts.extend(rhs.expanded_contexts());

--- a/tests/integration/snapshots/integration__snapshot__template_injection-6.snap
+++ b/tests/integration/snapshots/integration__snapshot__template_injection-6.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"template-injection/issue-339-repro.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"template-injection/issue-339-repro.yml\")).run()?"
 ---
 info[template-injection]: code injection via template expansion
   --> @@INPUT@@:27:9
@@ -11,7 +10,7 @@ info[template-injection]: code injection via template expansion
 28 |           id: run-id
 29 | /         run: |
 30 | |           echo "run-id=${{ fromJson(steps.runs.outputs.data).workflow_runs[0].id }}" >> "$GITHUB_OUTPUT"
-   | |_________________________________________________________________________________________________________- info: steps.runs.outputs.data may expand into attacker-controllable code
+   | |_________________________________________________________________________________________________________- info: fromJson(steps.runs.outputs.data).workflow_runs[0].id may expand into attacker-controllable code
    |
    = note: audit confidence → Low
 

--- a/tests/integration/test-data/template-injection/dataflow.yml
+++ b/tests/integration/test-data/template-injection/dataflow.yml
@@ -1,0 +1,29 @@
+name: template-injection-dataflow
+
+on: pull_request
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      # OK: dangerous context but without dataflow
+      - name: ok
+        run: |
+          echo "issue is foo: ${{ github.event.pull_request.title == 'foo' }}"
+          echo "issue contains foo: ${{ contains(github.event.pull_request.title, 'foo') }}"
+
+      # NOT OK: function call propagates dataflow
+      - name: notok
+        run: |
+          echo "${{ toJSON(github.event.pull_request.title) }}"
+          echo "${{ format('{0}', github.event.pull_request.title) }}"
+          echo "${{ join(github.event.pull_request.labels.*.name) }}"
+
+      # NOT OK: control flow propagates dataflow
+      - name: notok-2
+        run: |
+          echo "${{ github.event.pull_request.title || github.event.issue.title }}"
+          echo "${{ false || github.event.issue.title }}"


### PR DESCRIPTION
Fixes #624.

This will make audits like `template-injection` more precise.

Signed-off-by: William Woodruff <william@yossarian.net>