### PR TITLE
bugfix: cache-poisoning: fix false positive for docker/setup-buildx-action

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,6 +17,8 @@ of `zizmor`.
   to determine whether contexts actually expand in an unsafe manner,
   making it significantly more accurate (#640)
 * The [cache-poisoning] audit is now aware of @jdx/mise-action (#645)
+* The [cache-poisoning] audit is now significantly more accurate
+  when analyzing workflows that use @docker/setup-buildx-action (#644)
 
 ### Bug Fixes 🐛
 

--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -7,7 +7,7 @@ use github_actions_models::workflow::event::{BareEvent, BranchFilters, OptionalB
 
 use crate::audit::{Audit, audit_meta};
 use crate::finding::{Confidence, Finding, Severity};
-use crate::models::coordinate::{ActionCoordinate, Control, ControlFieldType, Toggle, Usage};
+use crate::models::coordinate::{ActionCoordinate, ControlExpr, ControlFieldType, Toggle, Usage};
 use crate::models::{JobExt as _, NormalJob, Step, StepCommon, Steps};
 use crate::state::AuditState;
 
@@ -19,104 +19,140 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/actions/cache/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("actions/cache").unwrap(),
-            control: Control::new(Toggle::OptOut, "lookup-only", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(
+                Toggle::OptOut,
+                "lookup-only",
+                ControlFieldType::Boolean,
+                true,
+            ),
         },
         // https://github.com/actions/setup-java/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("actions/setup-java").unwrap(),
-            control: Control::new(Toggle::OptIn, "cache", ControlFieldType::String),
-            enabled_by_default: false,
+            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::String, false),
         },
         // https://github.com/actions/setup-go/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("actions/setup-go").unwrap(),
-            control: Control::new(Toggle::OptIn, "cache", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
         },
         // https://github.com/actions/setup-node/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("actions/setup-node").unwrap(),
-            control: Control::new(Toggle::OptIn, "cache", ControlFieldType::String),
-            enabled_by_default: false,
+            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::String, false),
         },
         // https://github.com/actions/setup-python/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("actions/setup-python").unwrap(),
-            control: Control::new(Toggle::OptIn, "cache", ControlFieldType::String),
-            enabled_by_default: false,
+            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::String, false),
         },
         // https://github.com/actions/setup-dotnet/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("actions/setup-dotnet").unwrap(),
-            control: Control::new(Toggle::OptIn, "cache", ControlFieldType::Boolean),
-            enabled_by_default: false,
+            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::Boolean, false),
         },
         // https://github.com/astral-sh/setup-uv/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("astral-sh/setup-uv").unwrap(),
-            control: Control::new(Toggle::OptOut, "enable-cache", ControlFieldType::String),
-            enabled_by_default: true,
+            control: ControlExpr::single(
+                Toggle::OptOut,
+                "enable-cache",
+                ControlFieldType::String,
+                true,
+            ),
         },
         // https://github.com/Swatinem/rust-cache/blob/master/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("Swatinem/rust-cache").unwrap(),
-            control: Control::new(Toggle::OptOut, "lookup-only", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(
+                Toggle::OptOut,
+                "lookup-only",
+                ControlFieldType::Boolean,
+                true,
+            ),
         },
         // https://github.com/ruby/setup-ruby/blob/master/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("ruby/setup-ruby").unwrap(),
-            control: Control::new(Toggle::OptIn, "bundler-cache", ControlFieldType::Boolean),
-            enabled_by_default: false,
+            control: ControlExpr::single(
+                Toggle::OptIn,
+                "bundler-cache",
+                ControlFieldType::Boolean,
+                false,
+            ),
         },
         // https://github.com/PyO3/maturin-action/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("PyO3/maturin-action").unwrap(),
-            control: Control::new(Toggle::OptIn, "sccache", ControlFieldType::Boolean),
-            enabled_by_default: false,
+            control: ControlExpr::single(
+                Toggle::OptIn,
+                "sccache",
+                ControlFieldType::Boolean,
+                false,
+            ),
         },
         // https://github.com/mlugg/setup-zig/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("mlugg/setup-zig").unwrap(),
-            control: Control::new(Toggle::OptIn, "use-cache", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(
+                Toggle::OptIn,
+                "use-cache",
+                ControlFieldType::Boolean,
+                true,
+            ),
         },
         // https://github.com/oven-sh/setup-bun/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("oven-sh/setup-bun").unwrap(),
-            control: Control::new(Toggle::OptOut, "no-cache", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(
+                Toggle::OptOut,
+                "no-cache",
+                ControlFieldType::Boolean,
+                true,
+            ),
         },
         // https://github.com/DeterminateSystems/magic-nix-cache-action/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("DeterminateSystems/magic-nix-cache-action").unwrap(),
-            control: Control::new(Toggle::OptIn, "use-gha-cache", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(
+                Toggle::OptIn,
+                "use-gha-cache",
+                ControlFieldType::Boolean,
+                true,
+            ),
         },
         // https://github.com/graalvm/setup-graalvm/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("graalvm/setup-graalvm").unwrap(),
-            control: Control::new(Toggle::OptIn, "cache", ControlFieldType::String),
-            enabled_by_default: false,
+            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::String, false),
         },
         // https://github.com/gradle/actions/blob/main/setup-gradle/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("gradle/actions/setup-gradle").unwrap(),
-            control: Control::new(Toggle::OptOut, "cache-disabled", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(
+                Toggle::OptOut,
+                "cache-disabled",
+                ControlFieldType::Boolean,
+                true,
+            ),
         },
         // https://github.com/docker/setup-buildx-action/blob/master/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("docker/setup-buildx-action").unwrap(),
-            control: Control::new(Toggle::OptIn, "cache-binary", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::all([
+                ControlExpr::single(
+                    Toggle::OptIn,
+                    "cache-binary",
+                    ControlFieldType::Boolean,
+                    true,
+                ),
+                ControlExpr::single(Toggle::OptIn, "version", ControlFieldType::String, false),
+            ]),
         },
         // https://github.com/actions-rust-lang/setup-rust-toolchain/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("actions-rust-lang/setup-rust-toolchain").unwrap(),
-            control: Control::new(Toggle::OptIn, "cache", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
         },
         // https://github.com/Mozilla-Actions/sccache-action/blob/main/action.yml
         ActionCoordinate::NotConfigurable(
@@ -149,8 +185,7 @@ static KNOWN_PUBLISHER_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::new(
         // Container registries
         ActionCoordinate::Configurable {
             uses: Uses::from_str("docker/build-push-action").unwrap(),
-            control: Control::new(Toggle::OptIn, "push", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(Toggle::OptIn, "push", ControlFieldType::Boolean, true),
         },
         ActionCoordinate::NotConfigurable(
             Uses::from_str("redhat-actions/push-to-registry").unwrap(),

--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -165,8 +165,7 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         // https://github.com/jdx/mise-action/blob/main/action.yml
         ActionCoordinate::Configurable {
             uses: Uses::from_str("jdx/mise-action").unwrap(),
-            control: Control::new(Toggle::OptIn, "cache", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(Toggle::OptIn, "cache", ControlFieldType::Boolean, true),
         },
     ]
 });

--- a/src/models.rs
+++ b/src/models.rs
@@ -600,7 +600,7 @@ impl<'w> Step<'w> {
     }
 
     /// Returns this step's parent [`NormalJob`].
-    pub(crate) fn job(&self) -> &'w NormalJob {
+    pub(crate) fn job(&self) -> &NormalJob<'w> {
         &self.parent
     }
 

--- a/src/models/coordinate.rs
+++ b/src/models/coordinate.rs
@@ -13,7 +13,10 @@
 // able to express things like
 // "match foo/bar if foo: A and not bar: B and baz: /abcd/"
 
+use std::ops::{BitAnd, BitOr};
+
 use github_actions_models::common::{EnvValue, Uses, expr::ExplicitExpr};
+use indexmap::IndexMap;
 
 use super::{StepBodyCommon, StepCommon};
 use crate::models::uses::RepositoryUsesExt as _;
@@ -22,10 +25,8 @@ pub(crate) enum ActionCoordinate {
     Configurable {
         /// The `uses:` clause of the coordinate
         uses: Uses,
-        /// The input that controls the coordinate
-        control: Control,
-        /// Whether or not the behavior is the default
-        enabled_by_default: bool,
+        /// The expression of fields that controls the coordinate
+        control: ControlExpr,
     },
     NotConfigurable(Uses),
 }
@@ -35,34 +36,6 @@ impl ActionCoordinate {
         match self {
             ActionCoordinate::Configurable { uses, .. } => uses,
             ActionCoordinate::NotConfigurable(inner) => inner,
-        }
-    }
-
-    /// Returns the "declared" usage from a `with:` field, modulo a toggle.
-    fn declared_usage(
-        &self,
-        value: &EnvValue,
-        toggle: &Toggle,
-        field_type: &ControlFieldType,
-    ) -> Option<Usage> {
-        match value.to_string().as_str() {
-            // Handle `false` specially, since we need to invert the toggle.
-            "false" if matches!(field_type, ControlFieldType::Boolean) => match toggle {
-                Toggle::OptIn => None,
-                Toggle::OptOut => Some(Usage::DirectOptIn),
-            },
-            // NOTE: We don't bother checking for string or other-typed fields here,
-            // since it's all stringly-typed under the hood.
-            other => match ExplicitExpr::from_curly(other) {
-                // If it's not an expression, all we know is that it's likely a
-                // fixed sentinel value.
-                // This catches the `true` boolean case as well.
-                None => match toggle {
-                    Toggle::OptIn => Some(Usage::DirectOptIn),
-                    Toggle::OptOut => None,
-                },
-                Some(_) => Some(Usage::ConditionalOptIn),
-            },
         }
     }
 
@@ -91,27 +64,29 @@ impl ActionCoordinate {
         }
 
         match self {
-            ActionCoordinate::Configurable {
-                uses: _,
-                control,
-                enabled_by_default,
-            } => {
-                // We need to inspect this `uses:`'s configuration to determine its semantics.
-                match with.get(control.field_name) {
-                    Some(field_value) => {
-                        // The declared usage is whatever the user explicitly configured,
-                        // which might be inverted if the toggle semantics are opt-out instead.
-                        self.declared_usage(field_value, &control.toggle, &control.field_type)
-                    }
-                    None => {
-                        // If the controlling field is not present, the default dictates the semantics.
-                        if *enabled_by_default {
-                            Some(Usage::DefaultActionBehaviour)
-                        } else {
-                            None
-                        }
-                    }
+            ActionCoordinate::Configurable { uses: _, control } => {
+                match control.eval(with) {
+                    ControlStatus::DefaultSatisfied => Some(Usage::DefaultActionBehaviour),
+                    ControlStatus::Satisfied => Some(Usage::DirectOptIn),
+                    ControlStatus::NotSatisfied => None,
+                    ControlStatus::Conditional => Some(Usage::ConditionalOptIn),
                 }
+                // // We need to inspect this `uses:`'s configuration to determine its semantics.
+                // match with.get(control.field_name) {
+                //     Some(field_value) => {
+                //         // The declared usage is whatever the user explicitly configured,
+                //         // which might be inverted if the toggle semantics are opt-out instead.
+                //         self.declared_usage(field_value, &control.toggle, &control.field_type)
+                //     }
+                //     None => {
+                //         // If the controlling field is not present, the default dictates the semantics.
+                //         if *enabled_by_default {
+                //             Some(Usage::DefaultActionBehaviour)
+                //         } else {
+                //             None
+                //         }
+                //     }
+                // }
             }
             // The mere presence of this `uses:` implies the expected usage semantics.
             ActionCoordinate::NotConfigurable(_) => Some(Usage::Always),
@@ -135,26 +110,182 @@ pub(crate) enum ControlFieldType {
     String,
 }
 
-/// The input that controls the behavior of a configurable action.
-pub(crate) struct Control {
-    /// What kind of toggle the input is.
-    pub(crate) toggle: Toggle,
-    /// The field that controls the action's behavior.
-    pub(crate) field_name: &'static str,
-    /// The type of the field that controls the action's behavior.
-    pub(crate) field_type: ControlFieldType,
+/// The result of evaluating a control expression.
+#[derive(Copy, Clone, PartialEq)]
+pub(crate) enum ControlStatus {
+    /// The control expression is satisfied by default.
+    DefaultSatisfied,
+    /// The control expression is satisfied.
+    Satisfied,
+    /// The control expression is not satisfied.
+    NotSatisfied,
+    /// The control expression is conditionally satisfied,
+    /// i.e. depends on an actions expression or similar.
+    Conditional,
 }
 
-impl Control {
-    pub(crate) fn new(
+impl BitAnd for ControlStatus {
+    type Output = Self;
+
+    fn bitand(self, rhs: Self) -> Self::Output {
+        // NOTE: This could be done less literally, but I find it easier to read.
+        match (self, rhs) {
+            (ControlStatus::DefaultSatisfied, ControlStatus::DefaultSatisfied) => {
+                ControlStatus::DefaultSatisfied
+            }
+            (ControlStatus::DefaultSatisfied, ControlStatus::Satisfied) => ControlStatus::Satisfied,
+            (ControlStatus::DefaultSatisfied, ControlStatus::NotSatisfied) => {
+                ControlStatus::NotSatisfied
+            }
+            (ControlStatus::DefaultSatisfied, ControlStatus::Conditional) => {
+                ControlStatus::Conditional
+            }
+            (ControlStatus::Satisfied, ControlStatus::DefaultSatisfied) => ControlStatus::Satisfied,
+            (ControlStatus::Satisfied, ControlStatus::Satisfied) => ControlStatus::Satisfied,
+            (ControlStatus::Satisfied, ControlStatus::NotSatisfied) => ControlStatus::NotSatisfied,
+            (ControlStatus::Satisfied, ControlStatus::Conditional) => ControlStatus::Conditional,
+            (ControlStatus::NotSatisfied, ControlStatus::DefaultSatisfied) => {
+                ControlStatus::NotSatisfied
+            }
+            (ControlStatus::NotSatisfied, ControlStatus::Satisfied) => ControlStatus::NotSatisfied,
+            (ControlStatus::NotSatisfied, ControlStatus::NotSatisfied) => {
+                ControlStatus::NotSatisfied
+            }
+            (ControlStatus::NotSatisfied, ControlStatus::Conditional) => {
+                ControlStatus::NotSatisfied
+            }
+            (ControlStatus::Conditional, ControlStatus::DefaultSatisfied) => {
+                ControlStatus::Satisfied
+            }
+            (ControlStatus::Conditional, ControlStatus::Satisfied) => ControlStatus::Conditional,
+            (ControlStatus::Conditional, ControlStatus::NotSatisfied) => {
+                ControlStatus::NotSatisfied
+            }
+            (ControlStatus::Conditional, ControlStatus::Conditional) => ControlStatus::Conditional,
+        }
+    }
+}
+
+impl BitOr for ControlStatus {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        // TODO: Does this mapping make sense?
+        match (self, rhs) {
+            (ControlStatus::DefaultSatisfied, ControlStatus::DefaultSatisfied) => {
+                ControlStatus::DefaultSatisfied
+            }
+            (ControlStatus::DefaultSatisfied, ControlStatus::Satisfied) => ControlStatus::Satisfied,
+            (ControlStatus::DefaultSatisfied, ControlStatus::NotSatisfied) => {
+                ControlStatus::DefaultSatisfied
+            }
+            (ControlStatus::DefaultSatisfied, ControlStatus::Conditional) => {
+                ControlStatus::DefaultSatisfied
+            }
+            (ControlStatus::Satisfied, ControlStatus::DefaultSatisfied) => ControlStatus::Satisfied,
+            (ControlStatus::Satisfied, ControlStatus::Satisfied) => ControlStatus::Satisfied,
+            (ControlStatus::Satisfied, ControlStatus::NotSatisfied) => ControlStatus::Satisfied,
+            (ControlStatus::Satisfied, ControlStatus::Conditional) => ControlStatus::Satisfied,
+            (ControlStatus::NotSatisfied, ControlStatus::DefaultSatisfied) => {
+                ControlStatus::DefaultSatisfied
+            }
+            (ControlStatus::NotSatisfied, ControlStatus::Satisfied) => ControlStatus::Satisfied,
+            (ControlStatus::NotSatisfied, ControlStatus::NotSatisfied) => {
+                ControlStatus::NotSatisfied
+            }
+            (ControlStatus::NotSatisfied, ControlStatus::Conditional) => ControlStatus::Conditional,
+            (ControlStatus::Conditional, ControlStatus::DefaultSatisfied) => {
+                ControlStatus::DefaultSatisfied
+            }
+            (ControlStatus::Conditional, ControlStatus::Satisfied) => ControlStatus::Satisfied,
+            (ControlStatus::Conditional, ControlStatus::NotSatisfied) => ControlStatus::Conditional,
+            (ControlStatus::Conditional, ControlStatus::Conditional) => ControlStatus::Conditional,
+        }
+    }
+}
+
+/// An "expression" of control fields.
+///
+/// This allows us to express basic quantified logic, such as
+/// "all/any of these fields must be satisfied".
+///
+/// This is made slightly more complicated by the fact that our logic is
+/// three-valued: control fields can be satisfied, not satisfied, or conditionally
+/// satisfied.
+pub(crate) enum ControlExpr {
+    Single {
+        /// What kind of toggle the input is.
+        toggle: Toggle,
+        /// The field that controls the action's behavior.
+        field_name: &'static str,
+        /// The type of the field that controls the action's behavior.
+        field_type: ControlFieldType,
+        /// Whether this control is enabled by default, if not present.
+        enabled_by_default: bool,
+    },
+    All(Vec<ControlExpr>),
+    #[allow(dead_code)]
+    Any(Vec<ControlExpr>),
+}
+
+impl ControlExpr {
+    pub(crate) fn single(
         toggle: Toggle,
         field_name: &'static str,
         field_type: ControlFieldType,
+        enabled_by_default: bool,
     ) -> Self {
-        Self {
+        Self::Single {
             toggle,
             field_name,
             field_type,
+            enabled_by_default,
+        }
+    }
+
+    pub(crate) fn all(exprs: impl IntoIterator<Item = ControlExpr>) -> Self {
+        Self::All(exprs.into_iter().collect())
+    }
+
+    pub(crate) fn eval(&self, with: &IndexMap<String, EnvValue>) -> ControlStatus {
+        match self {
+            ControlExpr::Single {
+                toggle,
+                field_name,
+                field_type,
+                enabled_by_default,
+            } => {
+                // If the controlling field is not present, the default dictates the semantics.
+                if let Some(field_value) = with.get(*field_name) {
+                    match field_value.to_string().as_str() {
+                        "false" if matches!(field_type, ControlFieldType::Boolean) => {
+                            match toggle {
+                                Toggle::OptIn => ControlStatus::NotSatisfied,
+                                Toggle::OptOut => ControlStatus::Satisfied,
+                            }
+                        }
+                        other => match ExplicitExpr::from_curly(other) {
+                            None => match toggle {
+                                Toggle::OptIn => ControlStatus::Satisfied,
+                                Toggle::OptOut => ControlStatus::NotSatisfied,
+                            },
+                            Some(_) => ControlStatus::Conditional,
+                        },
+                    }
+                } else if *enabled_by_default {
+                    ControlStatus::DefaultSatisfied
+                } else {
+                    ControlStatus::NotSatisfied
+                }
+            }
+            ControlExpr::All(exprs) => exprs
+                .iter()
+                .map(|expr| expr.eval(with))
+                .fold(ControlStatus::Satisfied, |acc, expr| acc & expr),
+            ControlExpr::Any(exprs) => exprs
+                .iter()
+                .map(|expr| expr.eval(with))
+                .fold(ControlStatus::NotSatisfied, |acc, expr| acc | expr),
         }
     }
 }
@@ -174,7 +305,7 @@ mod tests {
     use github_actions_models::{common::Uses, workflow::job::Step};
 
     use super::{ActionCoordinate, StepCommon};
-    use crate::models::coordinate::{Control, ControlFieldType, Toggle, Usage};
+    use crate::models::coordinate::{ControlExpr, ControlFieldType, Toggle, Usage};
 
     // Test-only trait impl.
     impl<'s> StepCommon<'s> for Step {
@@ -228,8 +359,7 @@ mod tests {
         // missing the needed control.
         let coord = ActionCoordinate::Configurable {
             uses: Uses::from_str("foo/bar").unwrap(),
-            control: Control::new(Toggle::OptIn, "set-me", ControlFieldType::Boolean),
-            enabled_by_default: false,
+            control: ControlExpr::single(Toggle::OptIn, "set-me", ControlFieldType::Boolean, false),
         };
         let step: Step = serde_yaml::from_str("uses: foo/bar").unwrap();
         assert_eq!(coord.usage(&step), None);
@@ -245,8 +375,7 @@ mod tests {
         // Coordinate `uses:` matches and is enabled by default.
         let coord = ActionCoordinate::Configurable {
             uses: Uses::from_str("foo/bar").unwrap(),
-            control: Control::new(Toggle::OptIn, "set-me", ControlFieldType::Boolean),
-            enabled_by_default: true,
+            control: ControlExpr::single(Toggle::OptIn, "set-me", ControlFieldType::Boolean, true),
         };
         let step: Step = serde_yaml::from_str("uses: foo/bar").unwrap();
         assert_eq!(coord.usage(&step), Some(Usage::DefaultActionBehaviour));
@@ -263,8 +392,12 @@ mod tests {
         // the default.
         let coord = ActionCoordinate::Configurable {
             uses: Uses::from_str("foo/bar").unwrap(),
-            control: Control::new(Toggle::OptOut, "disable-cache", ControlFieldType::Boolean),
-            enabled_by_default: false,
+            control: ControlExpr::single(
+                Toggle::OptOut,
+                "disable-cache",
+                ControlFieldType::Boolean,
+                false,
+            ),
         };
         let step: Step = serde_yaml::from_str("uses: foo/bar").unwrap();
         assert_eq!(coord.usage(&step), None);

--- a/tests/integration/snapshot.rs
+++ b/tests/integration/snapshot.rs
@@ -341,6 +341,12 @@ fn cache_poisoning() -> Result<()> {
             .run()?
     );
 
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("cache-poisoning/issue-642-repro.yml"))
+            .run()?
+    );
+
     Ok(())
 }
 

--- a/tests/integration/snapshots/integration__snapshot__cache_poisoning-15.snap
+++ b/tests/integration/snapshots/integration__snapshot__cache_poisoning-15.snap
@@ -1,0 +1,20 @@
+---
+source: tests/integration/snapshot.rs
+expression: "zizmor().input(input_under_test(\"cache-poisoning/issue-642-repro.yml\")).run()?"
+snapshot_kind: text
+---
+error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
+  --> @@INPUT@@:20:9
+   |
+15 | /         with:
+16 | |           cache-binary: true
+17 | |           version: latest
+   | |_________________________^ opt-in for caching here
+18 |
+19 |         - name: Build docker
+20 |           uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ runtime artifacts usually published here
+   |
+   = note: audit confidence → Low
+
+1 finding: 0 unknown, 0 informational, 0 low, 0 medium, 1 high

--- a/tests/integration/test-data/cache-poisoning/issue-378-repro.yml
+++ b/tests/integration/test-data/cache-poisoning/issue-378-repro.yml
@@ -14,6 +14,7 @@ jobs:
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
         with:
           cache-binary: true
+          version: latest
 
       - name: Build docker
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355

--- a/tests/integration/test-data/cache-poisoning/issue-642-repro.yml
+++ b/tests/integration/test-data/cache-poisoning/issue-642-repro.yml
@@ -1,0 +1,39 @@
+# repro case for https://github.com/woodruffw/zizmor/issues/642
+
+name: issue-642
+
+on: push
+
+permissions: {}
+
+jobs:
+  issue-642-true-positive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
+        with:
+          cache-binary: true
+          version: latest
+
+      - name: Build docker
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  issue-642-true-negative:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5
+        with:
+          # cache-binary is set but version is not, meaning that
+          # caching is not actually used.
+          cache-binary: true
+
+      - name: Build docker
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This is an initial stab at exposing greater generality when evaluating whether a set of controls are "satisfied" for the purpose of considering an action enabled.

Doing this while also preserving the concept of "default enablement" results in some very wonky 4-valued logic, since there are 4 different states a control can evaluate to:

1. Satisfied by default
2. Satisfied through evaluation
3. Not satisfied through evaluation
4. "Conditional," i.e. we don't know because it's driven by an expression or similar

This is a little hard to follow, so I need to think about this more before actually merging it. However, the tests _do_ pass and I've also added a successful test for the original bug case that spurred this.

Fixes #642.