### PR TITLE
feat: cache-poisoning: add jdx/mise-action to cache aware actions

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -16,6 +16,7 @@ of `zizmor`.
 * The [template-injection] audit is now performs dataflow analysis
   to determine whether contexts actually expand in an unsafe manner,
   making it significantly more accurate (#640)
+* The [cache-poisoning] audit is now aware of @jdx/mise-action (#645)
 
 ### Bug Fixes 🐛
 

--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -126,6 +126,12 @@ static KNOWN_CACHE_AWARE_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::ne
         ActionCoordinate::NotConfigurable(
             Uses::from_str("nix-community/cache-nix-action").unwrap(),
         ),
+        // https://github.com/jdx/mise-action/blob/main/action.yml
+        ActionCoordinate::Configurable {
+            uses: Uses::from_str("jdx/mise-action").unwrap(),
+            control: Control::new(Toggle::OptIn, "cache", ControlFieldType::Boolean),
+            enabled_by_default: true,
+        },
     ]
 });
 


### PR DESCRIPTION
Adds [`jdx/mise-action`](https://github.com/jdx/mise-action), the action to setup [`mise-en-place`](https://mise.jdx.dev/), to `KNOWN_CACHE_AWARE_ACTIONS`.
Related: #629