### PR TITLE
bugfix: bump github-actions-models to 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,9 +641,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "github-actions-models"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a17952a0374993a4c7f8df12bd75b3d1ed8fb9c78e8dbaa32cf451143faaaa"
+checksum = "f88a77162772250923dedd95b66ab64c45052f3df74e7e6319b000e57359c606"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clap-verbosity-flag = { version = "3.0.2", features = [
 ], default-features = false }
 etcetera = "0.10.0"
 flate2 = "1.1.0"
-github-actions-models = "0.26.0"
+github-actions-models = "0.27.0"
 http-cache-reqwest = "0.15.1"
 human-panic = "2.0.1"
 ignore = "0.4.23"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,6 +24,9 @@ of `zizmor`.
 
 * The [template-injection] audit no longer considers
   `github.event.pull_request.head.sha` dangerous (#636)
+* Fixed a bug where `zizmor` would fail to parse workflows
+  with `workflow_call` triggers that specified inputs without the
+  `required` field being present (#646)
 
 ## v1.5.2
 


### PR DESCRIPTION
See #646.