### PR TITLE
bugfix: bump yamlpath, fix #659

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3115,9 +3115,9 @@ checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
 
 [[package]]
 name = "yamlpath"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796a3f441fd5a8d00a2dac6ca0ce0f0b07b7e1997e014a32d4f17a9d39fbdc9f"
+checksum = "87c585ad15cb2a723978a39719af264133486ee68bd980e214ff43402e7b674a"
 dependencies = [
  "thiserror 2.0.9",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tree-sitter = "0.25.2"
 tree-sitter-bash = "0.23.3"
 tree-sitter-powershell = "0.25.2"
-yamlpath = "0.15.0"
+yamlpath = "0.16.0"
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -41,6 +41,8 @@ of `zizmor`.
 * Fixed a bug where `zizmor` would fail to parse workflows with
   `pull_request` or `pull_request_target` triggers that specified
   `types` as a scalar value (#653)
+* Fixed a crash where `zizmor` would fail to generate correct concrete
+  location spans for YAML inputs with comments inside block sequences (#660)
 
 ## v1.5.2
 

--- a/tests/integration/snapshot.rs
+++ b/tests/integration/snapshot.rs
@@ -163,6 +163,13 @@ fn unpinned_uses() -> Result<()> {
             .run()?
     );
 
+    insta::assert_snapshot!(
+        zizmor()
+            .input(input_under_test("unpinned-uses/issue-659-repro.yml"))
+            .args(["--pedantic"])
+            .run()?
+    );
+
     Ok(())
 }
 

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-5.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-5.snap
@@ -1,0 +1,40 @@
+---
+source: tests/integration/snapshot.rs
+expression: "zizmor().input(input_under_test(\"unpinned-uses/issue-659-repro.yml\")).args([\"--pedantic\"]).run()?"
+---
+warning[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:1:1
+   |
+ 1 | / # minimized from https://raw.githubusercontent.com/docker/actions-toolkit/59501e62b/.github/workflows/test.yml
+ 2 | | name: issue-659-repro
+...  |
+18 | |         with:
+19 | |           node-version: ${{ env.NODE_VERSION }}
+   | |________________________________________________- default permissions used due to no permissions: block
+   |
+   = note: audit confidence → Medium
+
+warning[excessive-permissions]: overly broad permissions
+  --> @@INPUT@@:8:3
+   |
+ 8 | /   test-itg:
+ 9 | |     runs-on: ${{ matrix.os }}
+...  |
+18 | |         with:
+19 | |           node-version: ${{ env.NODE_VERSION }}
+   | |                                                -
+   | |________________________________________________|
+   |                                                  this job
+   |                                                  default permissions used due to no permissions: block
+   |
+   = note: audit confidence → Medium
+
+help[unpinned-uses]: unpinned action reference
+  --> @@INPUT@@:17:9
+   |
+17 |         uses: actions/setup-node@v4
+   |         --------------------------- help: action is not pinned to a hash ref
+   |
+   = note: audit confidence → High
+
+3 findings: 0 unknown, 0 informational, 1 low, 2 medium, 0 high

--- a/tests/integration/test-data/unpinned-uses/issue-659-repro.yml
+++ b/tests/integration/test-data/unpinned-uses/issue-659-repro.yml
@@ -1,0 +1,19 @@
+# minimized from https://raw.githubusercontent.com/docker/actions-toolkit/59501e62b/.github/workflows/test.yml
+name: issue-659-repro
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-itg:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare-itg.outputs.includes) }}
+    steps:
+      - # FIXME: Needs to setup node twice on Windows due to a bug with runner
+        name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}


### PR DESCRIPTION
This fixes #659 by bumping `yamlpath`, which in turn contains a fix for pathing behavior when a YAML
block sequence contains an interceding comment
between a sequence member and its body.