### PR TITLE
ci: convert Dockerfile to Wolfi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,15 @@
 
 FROM cgr.dev/chainguard/wolfi-base:latest
 
+# Wolfi zizmor version to install
+# https://edu.chainguard.dev/open-source/wolfi/apk-version-selection/
+# (set as an argument to pair with zizmor releases)
+ARG ZIZMOR_VERSION
+
 RUN set -eux && \
     apk update && \
-    apk add zizmor && \
-    which zizmor
+    apk add zizmor=~${ZIZMOR_VERSION} && \
+    zizmor --version
 
 # Set the entrypoint to zizmor
 ENTRYPOINT ["/usr/bin/zizmor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,13 @@
-FROM python:3.13-slim-bullseye AS build
-
-LABEL org.opencontainers.image.source=https://github.com/woodruffw/zizmor
-
-# Zizmor version to install (set as an argument to pair with zizmor releases)
-ARG ZIZMOR_VERSION
-
-ENV PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
-
-RUN set -eux && \
-    apt-get update && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN pip install zizmor==${ZIZMOR_VERSION} && \
-    which zizmor
-
 # ------------------------------------------------------------------------------
 # Runtime image
 # ------------------------------------------------------------------------------
 
-FROM debian:bullseye-slim
+FROM cgr.dev/chainguard/wolfi-base:latest
 
-# Copy necessary files from build stage
-COPY --from=build /usr/local/bin/zizmor /app/zizmor
+RUN set -eux && \
+    apk update && \
+    apk add zizmor && \
+    which zizmor
 
 # Set the entrypoint to zizmor
-ENTRYPOINT ["/app/zizmor"]
+ENTRYPOINT ["/usr/bin/zizmor"]


### PR DESCRIPTION
This PR converts the Docker file from Debian to Wolfi.

`zizmor` is a first class Wolfi package and is automatically bumped to the newest version. This means that the build step (and `ZIZMOR_VERSION`) are unnecessary. Please let me know if you're interested in handling this differently: https://github.com/wolfi-dev/os/blob/main/zizmor.yaml

Unlike other distros, security is the top priority of Wolfi and contains zero CVEs. Here is a comparison between the suggested and current docker files using [grype](https://github.com/anchore/grype):

Suggested Wolfi-based Docker
```
[eslerm@ares zizmor]$ grype zizmor:demo
 ✔ Loaded image                                                                                           zizmor:demo 
 ✔ Parsed image                                   sha256:16967599aa8ac448e0387581a92e3f7e329be8e0e9d80db4bf58c0001c68f5de 
 ✔ Cataloged contents                                    8a4059e1d03f561d674bcff5f439d0cbe023c1100961402588268432e776b4a7 
   ├── ✔ Packages                        [270 packages]  
   ├── ✔ Executables                     [28 executables]  
   ├── ✔ File digests                    [81 files]  
   └── ✔ File metadata                   [81 locations]  
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored 
No vulnerabilities found
```

Current Debian-based Docker
```
[eslerm@ares zizmor]$ grype zizmor:original
 ✔ Loaded image                                                                                           zizmor:original 
 ✔ Parsed image                                   sha256:77f7c2b4a89b3c9bed1579125f8324399f4530f480eb47d53286b5a124bd4fa2 
 ✔ Cataloged contents                                    890479d9ad9a3fb8b4ebfeb54d5d6dd66e00898934db70ba4aae3c333eaed885 
   ├── ✔ Packages                        [96 packages]  
   ├── ✔ File metadata                   [3,440 locations]  
   ├── ✔ Executables                     [703 executables]  
   └── ✔ File digests                    [3,440 files]  
 ✔ Scanned for vulnerabilities     [97 vulnerability matches]  
   ├── by severity: 1 critical, 5 high, 19 medium, 6 low, 66 negligible
   └── by status:   0 fixed, 97 not-fixed, 0 ignored (1 dropped)
NAME                INSTALLED               FIXED-IN     TYPE  VULNERABILITY     SEVERITY   
apt                 2.2.4                                deb   CVE-2011-3374     Negligible  
bash                5.1-2+deb11u1           (won't fix)  deb   CVE-2022-3715     High        
bsdutils            1:2.36.1-8+deb11u2                   deb   CVE-2022-0563     Negligible  
coreutils           8.32-4+b1               (won't fix)  deb   CVE-2016-2781     Low         
coreutils           8.32-4+b1                            deb   CVE-2017-18018    Negligible  
gcc-10-base         10.2.1-6                             deb   CVE-2023-4039     Negligible  
gcc-9-base          9.3.0-22                             deb   CVE-2023-4039     Negligible  
gpgv                2.2.27-2+deb11u2        (won't fix)  deb   CVE-2025-30258    Low         
gpgv                2.2.27-2+deb11u2                     deb   CVE-2022-3219     Negligible  
libapt-pkg6.0       2.2.4                                deb   CVE-2011-3374     Negligible  
libblkid1           2.36.1-8+deb11u2                     deb   CVE-2022-0563     Negligible  
libc-bin            2.31-13+deb11u11        (won't fix)  deb   CVE-2025-0395     High        
libc-bin            2.31-13+deb11u11        (won't fix)  deb   CVE-2023-4806     Medium      
libc-bin            2.31-13+deb11u11        (won't fix)  deb   CVE-2023-4813     Medium      
libc-bin            2.31-13+deb11u11                     deb   CVE-2010-4756     Negligible  
libc-bin            2.31-13+deb11u11                     deb   CVE-2018-20796    Negligible  
libc-bin            2.31-13+deb11u11                     deb   CVE-2019-1010022  Negligible  
libc-bin            2.31-13+deb11u11                     deb   CVE-2019-1010023  Negligible  
libc-bin            2.31-13+deb11u11                     deb   CVE-2019-1010024  Negligible  
libc-bin            2.31-13+deb11u11                     deb   CVE-2019-1010025  Negligible  
libc-bin            2.31-13+deb11u11                     deb   CVE-2019-9192     Negligible  
libc6               2.31-13+deb11u11        (won't fix)  deb   CVE-2025-0395     High        
libc6               2.31-13+deb11u11        (won't fix)  deb   CVE-2023-4806     Medium      
libc6               2.31-13+deb11u11        (won't fix)  deb   CVE-2023-4813     Medium      
libc6               2.31-13+deb11u11                     deb   CVE-2010-4756     Negligible  
libc6               2.31-13+deb11u11                     deb   CVE-2018-20796    Negligible  
libc6               2.31-13+deb11u11                     deb   CVE-2019-1010022  Negligible  
libc6               2.31-13+deb11u11                     deb   CVE-2019-1010023  Negligible  
libc6               2.31-13+deb11u11                     deb   CVE-2019-1010024  Negligible  
libc6               2.31-13+deb11u11                     deb   CVE-2019-1010025  Negligible  
libc6               2.31-13+deb11u11                     deb   CVE-2019-9192     Negligible  
libdb5.3            5.3.28+dfsg1-0.8        (won't fix)  deb   CVE-2019-8457     Critical    
libgcc-s1           10.2.1-6                             deb   CVE-2023-4039     Negligible  
libgcrypt20         1.8.7-6                 (won't fix)  deb   CVE-2021-33560    High        
libgcrypt20         1.8.7-6                 (won't fix)  deb   CVE-2024-2236     Medium      
libgcrypt20         1.8.7-6                              deb   CVE-2018-6829     Negligible  
libgnutls30         3.7.1-5+deb11u7                      deb   CVE-2011-3389     Negligible  
libgssapi-krb5-2    1.18.3-6+deb11u6                     deb   CVE-2018-5709     Negligible  
libgssapi-krb5-2    1.18.3-6+deb11u6                     deb   CVE-2024-26458    Negligible  
libgssapi-krb5-2    1.18.3-6+deb11u6                     deb   CVE-2024-26461    Negligible  
libk5crypto3        1.18.3-6+deb11u6                     deb   CVE-2018-5709     Negligible  
libk5crypto3        1.18.3-6+deb11u6                     deb   CVE-2024-26458    Negligible  
libk5crypto3        1.18.3-6+deb11u6                     deb   CVE-2024-26461    Negligible  
libkrb5-3           1.18.3-6+deb11u6                     deb   CVE-2018-5709     Negligible  
libkrb5-3           1.18.3-6+deb11u6                     deb   CVE-2024-26458    Negligible  
libkrb5-3           1.18.3-6+deb11u6                     deb   CVE-2024-26461    Negligible  
libkrb5support0     1.18.3-6+deb11u6                     deb   CVE-2018-5709     Negligible  
libkrb5support0     1.18.3-6+deb11u6                     deb   CVE-2024-26458    Negligible  
libkrb5support0     1.18.3-6+deb11u6                     deb   CVE-2024-26461    Negligible  
libmount1           2.36.1-8+deb11u2                     deb   CVE-2022-0563     Negligible  
libpam-modules      1.4.0-9+deb11u1         (won't fix)  deb   CVE-2024-10041    Medium      
libpam-modules      1.4.0-9+deb11u1         (won't fix)  deb   CVE-2024-22365    Medium      
libpam-modules-bin  1.4.0-9+deb11u1         (won't fix)  deb   CVE-2024-10041    Medium      
libpam-modules-bin  1.4.0-9+deb11u1         (won't fix)  deb   CVE-2024-22365    Medium      
libpam-runtime      1.4.0-9+deb11u1         (won't fix)  deb   CVE-2024-10041    Medium      
libpam-runtime      1.4.0-9+deb11u1         (won't fix)  deb   CVE-2024-22365    Medium      
libpam0g            1.4.0-9+deb11u1         (won't fix)  deb   CVE-2024-10041    Medium      
libpam0g            1.4.0-9+deb11u1         (won't fix)  deb   CVE-2024-22365    Medium      
libpcre2-8-0        10.36-2+deb11u1                      deb   CVE-2022-41409    Negligible  
libpcre3            2:8.39-13                            deb   CVE-2017-11164    Negligible  
libpcre3            2:8.39-13                            deb   CVE-2017-16231    Negligible  
libpcre3            2:8.39-13                            deb   CVE-2017-7245     Negligible  
libpcre3            2:8.39-13                            deb   CVE-2017-7246     Negligible  
libpcre3            2:8.39-13                            deb   CVE-2019-20838    Negligible  
libsmartcols1       2.36.1-8+deb11u2                     deb   CVE-2022-0563     Negligible  
libssl1.1           1.1.1w-0+deb11u2        (won't fix)  deb   CVE-2024-13176    Medium      
libstdc++6          10.2.1-6                             deb   CVE-2023-4039     Negligible  
libsystemd0         247.3-7+deb11u6                      deb   CVE-2013-4392     Negligible  
libsystemd0         247.3-7+deb11u6                      deb   CVE-2020-13529    Negligible  
libsystemd0         247.3-7+deb11u6                      deb   CVE-2023-31437    Negligible  
libsystemd0         247.3-7+deb11u6                      deb   CVE-2023-31438    Negligible  
libsystemd0         247.3-7+deb11u6                      deb   CVE-2023-31439    Negligible  
libtinfo6           6.2+20201114-2+deb11u2  (won't fix)  deb   CVE-2023-50495    Medium      
libudev1            247.3-7+deb11u6                      deb   CVE-2013-4392     Negligible  
libudev1            247.3-7+deb11u6                      deb   CVE-2020-13529    Negligible  
libudev1            247.3-7+deb11u6                      deb   CVE-2023-31437    Negligible  
libudev1            247.3-7+deb11u6                      deb   CVE-2023-31438    Negligible  
libudev1            247.3-7+deb11u6                      deb   CVE-2023-31439    Negligible  
libuuid1            2.36.1-8+deb11u2                     deb   CVE-2022-0563     Negligible  
libzstd1            1.4.8+dfsg-2.1          (won't fix)  deb   CVE-2022-4899     High        
login               1:4.8.1-1               (won't fix)  deb   CVE-2023-4641     Medium      
login               1:4.8.1-1               (won't fix)  deb   CVE-2023-29383    Low         
login               1:4.8.1-1               (won't fix)  deb   CVE-2024-56433    Low         
login               1:4.8.1-1                            deb   CVE-2007-5686     Negligible  
login               1:4.8.1-1                            deb   CVE-2013-4235     Negligible  
mount               2.36.1-8+deb11u2                     deb   CVE-2022-0563     Negligible  
ncurses-base        6.2+20201114-2+deb11u2  (won't fix)  deb   CVE-2023-50495    Medium      
ncurses-bin         6.2+20201114-2+deb11u2  (won't fix)  deb   CVE-2023-50495    Medium      
passwd              1:4.8.1-1               (won't fix)  deb   CVE-2023-4641     Medium      
passwd              1:4.8.1-1               (won't fix)  deb   CVE-2023-29383    Low         
passwd              1:4.8.1-1               (won't fix)  deb   CVE-2024-56433    Low         
passwd              1:4.8.1-1                            deb   CVE-2007-5686     Negligible  
passwd              1:4.8.1-1                            deb   CVE-2013-4235     Negligible  
perl-base           5.32.1-4+deb11u4                     deb   CVE-2011-4116     Negligible  
perl-base           5.32.1-4+deb11u4                     deb   CVE-2023-31486    Negligible  
tar                 1.34+dfsg-1+deb11u1                  deb   CVE-2005-2541     Negligible  
util-linux          2.36.1-8+deb11u2                     deb   CVE-2022-0563     Negligible
```

Also, I'd love to help contribute to the Trophy case.