### PR TITLE
docs: recommend GitHubSecurityLab/actions-permissions

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -153,8 +153,10 @@ In practice, this means that workflows should almost always set
 `#!yaml permissions: {}` at the workflow level to disable all permissions
 by default, and then set specific job-level permissions as needed.
 
-Tools such as [GitHubSecurityLab/actions-permissions](https://github.com/GitHubSecurityLab/actions-permissions)
-can help finding the minimally required permissions.
+!!! tip
+
+    @GitHubSecurityLab/actions-permissions can help find the minimally required
+    permissions.
 
 !!! example
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -153,6 +153,9 @@ In practice, this means that workflows should almost always set
 `#!yaml permissions: {}` at the workflow level to disable all permissions
 by default, and then set specific job-level permissions as needed.
 
+Tools such as [GitHubSecurityLab/actions-permissions](https://github.com/GitHubSecurityLab/actions-permissions)
+can help finding the minimally required permissions.
+
 !!! example
 
     === "Before :warning:"


### PR DESCRIPTION
Recommends https://github.com/GitHubSecurityLab/actions-permissions to make it easier for users to find the minimally required permissions. That might be easier for users than pure trial and error, or digging through the GitHub API documentation to find the needed permissions.

If you are aware of other tools which can do this, maybe it would be worth mentioning them as well.

:warning: That action is currently still in beta and has some [limitations](https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor#known-limitations), but maybe it is useful nonetheless.