### PR TITLE
feat: github_api: improve 403 errors slightly

### DIFF
--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -5,7 +5,7 @@
 
 use std::{io::Read, ops::Deref, path::Path};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use camino::Utf8Path;
 use flate2::read::GzDecoder;
 use github_actions_models::common::RepositoryUses;

--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -5,7 +5,7 @@
 
 use std::{io::Read, ops::Deref, path::Path};
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use camino::Utf8Path;
 use flate2::read::GzDecoder;
 use github_actions_models::common::RepositoryUses;
@@ -172,6 +172,8 @@ impl Client {
         match resp.status() {
             StatusCode::OK => Ok(true),
             StatusCode::NOT_FOUND => Ok(false),
+            StatusCode::FORBIDDEN => Err(anyhow::Error::from(resp.error_for_status().unwrap_err())
+                .context("request forbidden; token permissions may be insufficient")),
             s => Err(anyhow!(
                 "{owner}/{repo}: error from GitHub API while checking branch {branch}: {s}"
             )),
@@ -190,6 +192,8 @@ impl Client {
         match resp.status() {
             StatusCode::OK => Ok(true),
             StatusCode::NOT_FOUND => Ok(false),
+            StatusCode::FORBIDDEN => Err(anyhow::Error::from(resp.error_for_status().unwrap_err())
+                .context("request forbidden; token permissions may be insufficient")),
             s => Err(anyhow!(
                 "{owner}/{repo}: error from GitHub API while checking tag {tag}: {s}"
             )),


### PR DESCRIPTION
This isn't 100% ideal, since there's some duplication and _ideally_ I'd be able to propagate the `.context` as a "tip" instead, for prettier rendering. But it should hopefully clarify some existing confusion.

Closes #691.