### PR TITLE
bugfix: fix e2e test failures on Windows

### DIFF
--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context as _, Result};
+use regex::{Captures, Regex};
 use std::{env::current_dir, io::ErrorKind};
 
 use assert_cmd::Command;
@@ -149,8 +150,16 @@ impl Zizmor {
             OutputMode::Both => [output.stderr, output.stdout].concat(),
         })?;
 
+        let input_placeholder = "@@INPUT@@";
+        let input_path_regex = Regex::new(&format!(r"{input_placeholder}[\\/\w.-]+"))?;
         for input in &self.inputs {
-            raw = raw.replace(input, "@@INPUT@@");
+            raw = raw.replace(input, input_placeholder);
+            // Normalize Windows '\' file paths to using '/'
+            raw = input_path_regex
+                .replace_all(&raw, |captures: &Captures| {
+                    captures.get(0).unwrap().as_str().replace("\\", "/")
+                })
+                .into_owned();
         }
 
         Ok(raw)

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -170,10 +170,13 @@ impl Zizmor {
         }
 
         let input_placeholder = "@@INPUT@@";
-        let input_path_regex = Regex::new(&format!(r"{input_placeholder}[\\/\w.-]+"))?;
         for input in &self.inputs {
             raw = raw.replace(input, input_placeholder);
-            // Normalize Windows '\' file paths to using '/'
+        }
+
+        // Normalize Windows '\' file paths to using '/', to get consistent snapshot test outputs
+        if cfg!(windows) {
+            let input_path_regex = Regex::new(&format!(r"{input_placeholder}[\\/\w.-]+"))?;
             raw = input_path_regex
                 .replace_all(&raw, |captures: &Captures| {
                     captures.get(0).unwrap().as_str().replace("\\", "/")

--- a/tests/integration/e2e.rs
+++ b/tests/integration/e2e.rs
@@ -186,7 +186,7 @@ fn invalid_config_file() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()
             .output(OutputMode::Stderr)
-            .config("/dev/null")
+            .config(if cfg!(windows) { "NUL" } else { "/dev/null" })
             .input(input_under_test("e2e-menagerie"))
             .run()?
     );


### PR DESCRIPTION
- `e2e::invalid_config_file`
Was previously failing because `/dev/null` does not exist on Windows. Have used `NUL` now for Windows.
    ```
    error: failed to load config: The system cannot find the path specified. (os error 3)
    ```
- `e2e::menagerie`
Was previously failing because the expected snapshot output contains the file path separator `/`, but on Windows it is `\`. Have added replacement logic.

Not sure if these changes are clean enough, or if they could be simplified. Feedback is appreciated!

`e2e::color_control_tty` and `e2e::progress_bar_tty` still fail for me because I don't have `unbuffer`. It seems there are [workarounds for Windows](https://stackoverflow.com/q/11516258) but I haven't tried this yet.