### PR TITLE
feat: reduce code duplication for workflow step handling

### DIFF
--- a/src/audit/artipacked.rs
+++ b/src/audit/artipacked.rs
@@ -8,11 +8,11 @@ use github_actions_models::{
 use itertools::Itertools as _;
 
 use super::{Audit, AuditLoadError, audit_meta};
-use crate::utils::split_patterns;
 use crate::{
     finding::{Confidence, Finding, Persona, Severity},
-    models::{JobExt, uses::RepositoryUsesExt as _},
+    models::{JobExt, StepCommon, uses::RepositoryUsesExt as _},
     state::AuditState,
+    utils::split_patterns,
 };
 
 pub(crate) struct Artipacked;

--- a/src/audit/bot_conditions.rs
+++ b/src/audit/bot_conditions.rs
@@ -4,7 +4,7 @@ use super::{Audit, AuditLoadError, AuditState, audit_meta};
 use crate::{
     expr::{self, Context, Expr},
     finding::{Confidence, Severity},
-    models::JobExt,
+    models::{JobExt, StepCommon},
 };
 
 pub(crate) struct BotConditions;

--- a/src/audit/forbidden_uses.rs
+++ b/src/audit/forbidden_uses.rs
@@ -36,14 +36,11 @@ impl ForbiddenUses {
         }
     }
 
-    fn process_step<'w>(
-        &self,
-        step: &impl StepCommon<'w>,
-    ) -> anyhow::Result<Vec<FindingBuilder<'w>>> {
+    fn process_step<'w>(&self, step: &impl StepCommon<'w>) -> Vec<FindingBuilder<'w>> {
         let mut findings = vec![];
 
         let Some(uses) = step.uses() else {
-            return Ok(vec![]);
+            return findings;
         };
 
         if self.use_denied(uses) {
@@ -61,7 +58,7 @@ impl ForbiddenUses {
             );
         };
 
-        Ok(findings)
+        findings
     }
 }
 
@@ -83,7 +80,7 @@ impl Audit for ForbiddenUses {
     }
 
     fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
-        self.process_step(step)?
+        self.process_step(step)
             .into_iter()
             .map(|f| f.build(step.workflow()))
             .collect()
@@ -93,7 +90,7 @@ impl Audit for ForbiddenUses {
         &self,
         step: &CompositeStep<'a>,
     ) -> anyhow::Result<Vec<Finding<'a>>> {
-        self.process_step(step)?
+        self.process_step(step)
             .into_iter()
             .map(|f| f.build(step.action()))
             .collect()

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -12,7 +12,7 @@ use tree_sitter::{
 
 use super::{Audit, AuditLoadError, audit_meta};
 use crate::finding::{Confidence, Finding, Severity};
-use crate::models::{JobExt as _, Step};
+use crate::models::{JobExt as _, Step, StepCommon};
 use crate::state::AuditState;
 use crate::utils;
 

--- a/src/audit/impostor_commit.rs
+++ b/src/audit/impostor_commit.rs
@@ -12,7 +12,7 @@ use super::{Audit, AuditLoadError, Job, audit_meta};
 use crate::{
     finding::{Confidence, Finding, Severity},
     github_api::{self, ComparisonStatus},
-    models::{JobExt as _, Workflow, uses::RepositoryUsesExt as _},
+    models::{JobExt as _, StepCommon, Workflow, uses::RepositoryUsesExt as _},
     state::AuditState,
 };
 

--- a/src/audit/insecure_commands.rs
+++ b/src/audit/insecure_commands.rs
@@ -9,7 +9,7 @@ use github_actions_models::workflow::job::StepBody;
 use super::{AuditLoadError, Job, audit_meta};
 use crate::audit::Audit;
 use crate::finding::{Confidence, Finding, Persona, Severity, SymbolicLocation};
-use crate::models::{JobExt as _, Steps, Workflow};
+use crate::models::{JobExt as _, StepCommon, Steps, Workflow};
 use crate::state::AuditState;
 
 pub(crate) struct InsecureCommands;

--- a/src/audit/obfuscation.rs
+++ b/src/audit/obfuscation.rs
@@ -69,10 +69,7 @@ impl Obfuscation {
         annotations
     }
 
-    fn process_step<'w>(
-        &self,
-        step: &impl StepCommon<'w>,
-    ) -> anyhow::Result<Vec<FindingBuilder<'w>>> {
+    fn process_step<'w>(&self, step: &impl StepCommon<'w>) -> Vec<FindingBuilder<'w>> {
         let mut findings = vec![];
 
         if let Some(Uses::Repository(uses)) = step.uses() {
@@ -91,7 +88,7 @@ impl Obfuscation {
             }
         }
 
-        Ok(findings)
+        findings
     }
 }
 
@@ -130,7 +127,7 @@ impl Audit for Obfuscation {
     }
 
     fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
-        self.process_step(step)?
+        self.process_step(step)
             .into_iter()
             .map(|f| f.build(step.workflow()))
             .collect()
@@ -140,7 +137,7 @@ impl Audit for Obfuscation {
         &self,
         step: &CompositeStep<'a>,
     ) -> anyhow::Result<Vec<Finding<'a>>> {
-        self.process_step(step)?
+        self.process_step(step)
             .into_iter()
             .map(|f| f.build(step.action()))
             .collect()

--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -11,7 +11,7 @@ use github_actions_models::common::{RepositoryUses, Uses};
 
 use super::{Audit, AuditLoadError, Job, audit_meta};
 use crate::finding::Finding;
-use crate::models::{CompositeStep, JobExt as _};
+use crate::models::{CompositeStep, JobExt as _, StepCommon};
 use crate::{
     finding::{Confidence, Severity},
     github_api,

--- a/src/audit/use_trusted_publishing.rs
+++ b/src/audit/use_trusted_publishing.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use super::{Audit, AuditLoadError, audit_meta};
 use crate::{
     finding::{Confidence, Severity},
-    models::uses::RepositoryUsesExt as _,
+    models::{StepCommon, uses::RepositoryUsesExt as _},
     state::AuditState,
 };
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -45,6 +45,9 @@ pub(crate) trait StepCommon<'s> {
     /// i.e. is not influenced by another expression.
     fn env_is_static(&self, name: &str) -> bool;
 
+    /// Returns a [`common::Uses`] for this step, if it has one.
+    fn uses(&self) -> Option<&common::Uses>;
+
     /// Returns this step's job's strategy, if present.
     ///
     /// Composite action steps have no strategy.
@@ -55,6 +58,10 @@ pub(crate) trait StepCommon<'s> {
 
     /// Returns a [`SymbolicLocation`] for this step.
     fn location(&self) -> SymbolicLocation<'s>;
+
+    /// Like [`Self::location()`], except with the step's `name`
+    /// key as the final path component if present.
+    fn location_with_name(&self) -> SymbolicLocation<'s>;
 }
 
 /// Represents an entire GitHub Actions workflow.
@@ -564,6 +571,10 @@ impl<'s> StepCommon<'s> for Step<'s> {
         utils::env_is_static(name, &envs)
     }
 
+    fn uses(&self) -> Option<&common::Uses> {
+        self.uses()
+    }
+
     fn strategy(&self) -> Option<&Strategy> {
         self.job().strategy.as_ref()
     }
@@ -587,6 +598,10 @@ impl<'s> StepCommon<'s> for Step<'s> {
 
     fn location(&self) -> SymbolicLocation<'s> {
         self.location()
+    }
+
+    fn location_with_name(&self) -> SymbolicLocation<'s> {
+        self.location_with_name()
     }
 }
 
@@ -855,6 +870,10 @@ impl<'s> StepCommon<'s> for CompositeStep<'s> {
         utils::env_is_static(name, &[env])
     }
 
+    fn uses(&self) -> Option<&common::Uses> {
+        self.uses()
+    }
+
     fn strategy(&self) -> Option<&Strategy> {
         None
     }
@@ -878,6 +897,10 @@ impl<'s> StepCommon<'s> for CompositeStep<'s> {
 
     fn location(&self) -> SymbolicLocation<'s> {
         self.location()
+    }
+
+    fn location_with_name(&self) -> SymbolicLocation<'s> {
+        self.location_with_name()
     }
 }
 

--- a/src/models/coordinate.rs
+++ b/src/models/coordinate.rs
@@ -334,6 +334,10 @@ mod tests {
             unimplemented!()
         }
 
+        fn uses(&self) -> Option<&github_actions_models::common::Uses> {
+            unimplemented!()
+        }
+
         fn strategy(&self) -> Option<&github_actions_models::workflow::job::Strategy> {
             unimplemented!()
         }
@@ -358,6 +362,10 @@ mod tests {
         }
 
         fn location(&self) -> crate::models::SymbolicLocation<'s> {
+            unimplemented!()
+        }
+
+        fn location_with_name(&self) -> crate::finding::SymbolicLocation<'s> {
             unimplemented!()
         }
     }


### PR DESCRIPTION
I noticed that multiple audit rules were handling `audit_step` and `audit_composite_step`, but previously their code was duplicated.

Therefore I tried to deduplicate it now. As part of that I also tried to make the `use` declarations a bit more consistent.

Hopefully I did not overlook something. Feedback is appreciated!