### PR TITLE
tests: check zizmor exit code

### DIFF
--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -154,20 +154,17 @@ impl Zizmor {
         };
 
         let mut raw = String::from_utf8(match self.output {
-            OutputMode::Stdout => output.stdout.clone(),
-            OutputMode::Stderr => output.stderr.clone(),
-            OutputMode::Both => [output.stderr.clone(), output.stdout.clone()].concat(),
+            OutputMode::Stdout => output.stdout,
+            OutputMode::Stderr => output.stderr,
+            OutputMode::Both => [output.stderr, output.stdout].concat(),
         })?;
 
-        // Exit codes used by zizmor, representing no findings or finding severity
-        let success_exit_codes = vec![0, 10, 11, 12, 13, 14];
         if let Some(exit_code) = output.status.code() {
-            let is_failure = !success_exit_codes.contains(&exit_code);
+            // There are other nonzero exit codes that don't indicate failure;
+            // 1 is our only failure code.
+            let is_failure = exit_code == 1;
             if is_failure != self.expects_failure {
-                anyhow::bail!(
-                    "zizmor exited with unexpected code {exit_code}:\n{}",
-                    String::from_utf8_lossy(&[output.stderr, output.stdout].concat())
-                );
+                anyhow::bail!("zizmor exited with unexpected code {exit_code}");
             }
         }
 

--- a/tests/integration/e2e.rs
+++ b/tests/integration/e2e.rs
@@ -185,7 +185,7 @@ fn issue_612_repro() -> Result<()> {
 fn invalid_config_file() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()
-            .output(OutputMode::Stderr)
+            .expects_failure(true)
             .config("/dev/null")
             .input(input_under_test("e2e-menagerie"))
             .run()?

--- a/tests/integration/snapshot.rs
+++ b/tests/integration/snapshot.rs
@@ -3,14 +3,14 @@
 //! TODO: This file is too big; break it into multiple
 //! modules, one per audit/conceptual group.
 
-use crate::common::{OutputMode, input_under_test, zizmor};
+use crate::common::{input_under_test, zizmor};
 use anyhow::Result;
 
 #[test]
 fn test_cant_retrieve() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()
-            .output(OutputMode::Stderr)
+            .expects_failure(true)
             .offline(true)
             .unsetenv("GH_TOKEN")
             .args(["pypa/sampleproject"])
@@ -24,7 +24,7 @@ fn test_cant_retrieve() -> Result<()> {
 fn test_invalid_inputs() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()
-            .output(OutputMode::Stderr)
+            .expects_failure(true)
             .offline(true)
             .input(input_under_test("invalid/invalid-workflow.yml"))
             .run()?
@@ -242,7 +242,7 @@ fn unpinned_uses() -> Result<()> {
     ] {
         insta::assert_snapshot!(
             zizmor()
-                .output(OutputMode::Stderr)
+                .expects_failure(true)
                 .config(input_under_test(
                     &format!("unpinned-uses/configs/{tc}.yml",)
                 ))


### PR DESCRIPTION
In case of an error, this makes it easier to understand that execution failed, compared to the current behavior which is just an empty snapshot output.