### PR TITLE
feat: further reduce step handling code duplication

### DIFF
--- a/src/audit/artipacked.rs
+++ b/src/audit/artipacked.rs
@@ -50,7 +50,7 @@ impl Audit for Artipacked {
         Ok(Self)
     }
 
-    fn audit_normal_job<'w>(&self, job: &super::NormalJob<'w>) -> Result<Vec<Finding<'w>>> {
+    fn audit_normal_job<'doc>(&self, job: &super::NormalJob<'doc>) -> Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         // First, collect all vulnerable checkouts and upload steps independently.

--- a/src/audit/bot_conditions.rs
+++ b/src/audit/bot_conditions.rs
@@ -21,10 +21,10 @@ impl Audit for BotConditions {
         Ok(Self)
     }
 
-    fn audit_normal_job<'w>(
+    fn audit_normal_job<'doc>(
         &self,
-        job: &super::NormalJob<'w>,
-    ) -> anyhow::Result<Vec<super::Finding<'w>>> {
+        job: &super::NormalJob<'doc>,
+    ) -> anyhow::Result<Vec<super::Finding<'doc>>> {
         let mut findings = vec![];
 
         // TODO: Consider other triggers as well?

--- a/src/audit/cache_poisoning.rs
+++ b/src/audit/cache_poisoning.rs
@@ -223,9 +223,9 @@ static KNOWN_PUBLISHER_ACTIONS: LazyLock<Vec<ActionCoordinate>> = LazyLock::new(
     ]
 });
 
-enum PublishingArtifactsScenario<'w> {
+enum PublishingArtifactsScenario<'doc> {
     UsingTypicalWorkflowTrigger,
-    UsingWellKnowPublisherAction(Step<'w>),
+    UsingWellKnowPublisherAction(Step<'doc>),
 }
 
 pub(crate) struct CachePoisoning;
@@ -270,11 +270,11 @@ impl CachePoisoning {
         })
     }
 
-    fn is_job_publishing_artifacts<'w>(
+    fn is_job_publishing_artifacts<'doc>(
         &self,
         trigger: &Trigger,
-        steps: Steps<'w>,
-    ) -> Option<PublishingArtifactsScenario<'w>> {
+        steps: Steps<'doc>,
+    ) -> Option<PublishingArtifactsScenario<'doc>> {
         if self.trigger_used_when_publishing_artifacts(trigger) {
             return Some(PublishingArtifactsScenario::UsingTypicalWorkflowTrigger);
         };
@@ -286,17 +286,17 @@ impl CachePoisoning {
         ))
     }
 
-    fn evaluate_cache_usage<'s>(&self, step: &impl StepCommon<'s>) -> Option<Usage> {
+    fn evaluate_cache_usage<'doc>(&self, step: &impl StepCommon<'doc>) -> Option<Usage> {
         KNOWN_CACHE_AWARE_ACTIONS
             .iter()
             .find_map(|coord| coord.usage(step))
     }
 
-    fn uses_cache_aware_step<'w>(
+    fn uses_cache_aware_step<'doc>(
         &self,
-        step: &Step<'w>,
-        scenario: &PublishingArtifactsScenario<'w>,
-    ) -> Option<Finding<'w>> {
+        step: &Step<'doc>,
+        scenario: &PublishingArtifactsScenario<'doc>,
+    ) -> Option<Finding<'doc>> {
         let cache_usage = self.evaluate_cache_usage(step)?;
 
         let (yaml_key, annotation) = match cache_usage {
@@ -353,7 +353,7 @@ impl Audit for CachePoisoning {
         Ok(Self)
     }
 
-    fn audit_normal_job<'w>(&self, job: &NormalJob<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_normal_job<'doc>(&self, job: &NormalJob<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
         let steps = job.steps();
         let trigger = &job.parent().on;

--- a/src/audit/dangerous_triggers.rs
+++ b/src/audit/dangerous_triggers.rs
@@ -18,7 +18,7 @@ impl Audit for DangerousTriggers {
         Ok(Self)
     }
 
-    fn audit_workflow<'w>(&self, workflow: &'w Workflow) -> Result<Vec<Finding<'w>>> {
+    fn audit_workflow<'doc>(&self, workflow: &'doc Workflow) -> Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
         if workflow.has_pull_request_target() {
             findings.push(

--- a/src/audit/excessive_permissions.rs
+++ b/src/audit/excessive_permissions.rs
@@ -47,10 +47,10 @@ impl Audit for ExcessivePermissions {
         Ok(Self)
     }
 
-    fn audit_workflow<'w>(
+    fn audit_workflow<'doc>(
         &self,
-        workflow: &'w crate::models::Workflow,
-    ) -> anyhow::Result<Vec<crate::finding::Finding<'w>>> {
+        workflow: &'doc crate::models::Workflow,
+    ) -> anyhow::Result<Vec<crate::finding::Finding<'doc>>> {
         let mut findings = vec![];
 
         let all_jobs_have_permissions = workflow

--- a/src/audit/forbidden_uses.rs
+++ b/src/audit/forbidden_uses.rs
@@ -36,7 +36,10 @@ impl ForbiddenUses {
         }
     }
 
-    fn process_step<'w>(&self, step: &impl StepCommon<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn process_step<'doc>(
+        &self,
+        step: &impl StepCommon<'doc>,
+    ) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         let Some(uses) = step.uses() else {
@@ -80,7 +83,7 @@ impl Audit for ForbiddenUses {
         Ok(Self { config })
     }
 
-    fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_step<'doc>(&self, step: &Step<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
         self.process_step(step)
     }
 

--- a/src/audit/forbidden_uses.rs
+++ b/src/audit/forbidden_uses.rs
@@ -55,7 +55,7 @@ impl ForbiddenUses {
                             .with_keys(&["uses".into()])
                             .annotated("use of this action is forbidden"),
                     )
-                    .build_with_document(step.document())?,
+                    .build(step)?,
             );
         };
 

--- a/src/audit/github_env.rs
+++ b/src/audit/github_env.rs
@@ -368,7 +368,7 @@ impl Audit for GitHubEnv {
         })
     }
 
-    fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_step<'doc>(&self, step: &Step<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         let workflow = step.workflow();
@@ -416,10 +416,10 @@ impl Audit for GitHubEnv {
         Ok(findings)
     }
 
-    fn audit_composite_step<'a>(
+    fn audit_composite_step<'doc>(
         &self,
-        step: &super::CompositeStep<'a>,
-    ) -> Result<Vec<Finding<'a>>> {
+        step: &super::CompositeStep<'doc>,
+    ) -> Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         let action::StepBody::Run { run, shell, .. } = &step.body else {

--- a/src/audit/hardcoded_container_credentials.rs
+++ b/src/audit/hardcoded_container_credentials.rs
@@ -26,10 +26,10 @@ impl Audit for HardcodedContainerCredentials {
         Ok(Self)
     }
 
-    fn audit_workflow<'w>(
+    fn audit_workflow<'doc>(
         &self,
-        workflow: &'w crate::models::Workflow,
-    ) -> anyhow::Result<Vec<crate::finding::Finding<'w>>> {
+        workflow: &'doc crate::models::Workflow,
+    ) -> anyhow::Result<Vec<crate::finding::Finding<'doc>>> {
         let mut findings = vec![];
 
         for job in workflow.jobs() {

--- a/src/audit/impostor_commit.rs
+++ b/src/audit/impostor_commit.rs
@@ -129,7 +129,7 @@ impl Audit for ImpostorCommit {
         Ok(ImpostorCommit { client })
     }
 
-    fn audit_workflow<'w>(&self, workflow: &'w Workflow) -> Result<Vec<Finding<'w>>> {
+    fn audit_workflow<'doc>(&self, workflow: &'doc Workflow) -> Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         for job in workflow.jobs() {

--- a/src/audit/insecure_commands.rs
+++ b/src/audit/insecure_commands.rs
@@ -63,11 +63,11 @@ impl InsecureCommands {
         }
     }
 
-    fn audit_steps<'w>(
+    fn audit_steps<'doc>(
         &self,
-        workflow: &'w Workflow,
-        steps: Steps<'w>,
-    ) -> Result<Vec<Finding<'w>>> {
+        workflow: &'doc Workflow,
+        steps: Steps<'doc>,
+    ) -> Result<Vec<Finding<'doc>>> {
         steps
             .into_iter()
             .filter_map(|step| {
@@ -104,7 +104,7 @@ impl Audit for InsecureCommands {
         Ok(Self)
     }
 
-    fn audit_workflow<'w>(&self, workflow: &'w Workflow) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_workflow<'doc>(&self, workflow: &'doc Workflow) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut results = vec![];
 
         match &workflow.env {
@@ -138,10 +138,10 @@ impl Audit for InsecureCommands {
         Ok(results)
     }
 
-    fn audit_composite_step<'a>(
+    fn audit_composite_step<'doc>(
         &self,
-        step: &super::CompositeStep<'a>,
-    ) -> Result<Vec<Finding<'a>>> {
+        step: &super::CompositeStep<'doc>,
+    ) -> Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         let action::StepBody::Run { env, .. } = &step.body else {

--- a/src/audit/insecure_commands.rs
+++ b/src/audit/insecure_commands.rs
@@ -9,7 +9,7 @@ use github_actions_models::workflow::job::StepBody;
 use super::{AuditLoadError, Job, audit_meta};
 use crate::audit::Audit;
 use crate::finding::{Confidence, Finding, Persona, Severity, SymbolicLocation};
-use crate::models::{JobExt as _, StepCommon, Steps, Workflow};
+use crate::models::{AsDocument, JobExt as _, StepCommon, Steps, Workflow};
 use crate::state::AuditState;
 
 pub(crate) struct InsecureCommands;
@@ -21,11 +21,11 @@ audit_meta!(
 );
 
 impl InsecureCommands {
-    fn insecure_commands_maybe_present<'w>(
+    fn insecure_commands_maybe_present<'a, 'doc>(
         &self,
-        doc: &'w impl AsRef<yamlpath::Document>,
-        location: SymbolicLocation<'w>,
-    ) -> Result<Finding<'w>> {
+        doc: &'a impl AsDocument<'a, 'doc>,
+        location: SymbolicLocation<'doc>,
+    ) -> Result<Finding<'doc>> {
         Self::finding()
             .confidence(Confidence::Low)
             .severity(Severity::High)
@@ -38,11 +38,11 @@ impl InsecureCommands {
             .build(doc)
     }
 
-    fn insecure_commands_allowed<'w>(
+    fn insecure_commands_allowed<'s, 'doc>(
         &self,
-        doc: &'w impl AsRef<yamlpath::Document>,
-        location: SymbolicLocation<'w>,
-    ) -> Result<Finding<'w>> {
+        doc: &'s impl AsDocument<'s, 'doc>,
+        location: SymbolicLocation<'doc>,
+    ) -> Result<Finding<'doc>> {
         Self::finding()
             .confidence(Confidence::High)
             .severity(Severity::High)

--- a/src/audit/known_vulnerable_actions.rs
+++ b/src/audit/known_vulnerable_actions.rs
@@ -139,7 +139,7 @@ impl KnownVulnerableActions {
                             .annotated(&id)
                             .with_url(format!("https://github.com/advisories/{id}")),
                     )
-                    .build_with_document(step.document())?,
+                    .build(step)?,
             );
         }
 

--- a/src/audit/known_vulnerable_actions.rs
+++ b/src/audit/known_vulnerable_actions.rs
@@ -120,7 +120,7 @@ impl KnownVulnerableActions {
         Ok(results)
     }
 
-    fn process_step<'w>(&self, step: &impl StepCommon<'w>) -> Result<Vec<Finding<'w>>> {
+    fn process_step<'doc>(&self, step: &impl StepCommon<'doc>) -> Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         let Some(Uses::Repository(uses)) = step.uses() else {
@@ -167,11 +167,11 @@ impl Audit for KnownVulnerableActions {
         Ok(Self { client })
     }
 
-    fn audit_step<'w>(&self, step: &Step<'w>) -> Result<Vec<Finding<'w>>> {
+    fn audit_step<'doc>(&self, step: &Step<'doc>) -> Result<Vec<Finding<'doc>>> {
         self.process_step(step)
     }
 
-    fn audit_composite_step<'a>(&self, step: &CompositeStep<'a>) -> Result<Vec<Finding<'a>>> {
+    fn audit_composite_step<'doc>(&self, step: &CompositeStep<'doc>) -> Result<Vec<Finding<'doc>>> {
         self.process_step(step)
     }
 }

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -8,7 +8,9 @@ use yamlpath::Document;
 
 use crate::{
     finding::{Finding, FindingBuilder, SymbolicLocation},
-    models::{Action, CompositeStep, Job, NormalJob, ReusableWorkflowCallJob, Step, Workflow},
+    models::{
+        Action, AsDocument, CompositeStep, Job, NormalJob, ReusableWorkflowCallJob, Step, Workflow,
+    },
     registry::InputKey,
     state::AuditState,
 };
@@ -48,13 +50,6 @@ impl AuditInput {
         }
     }
 
-    pub(crate) fn document(&self) -> &yamlpath::Document {
-        match self {
-            AuditInput::Workflow(workflow) => &workflow.document,
-            AuditInput::Action(action) => &action.document,
-        }
-    }
-
     pub(crate) fn line_index(&self) -> &LineIndex {
         match self {
             AuditInput::Workflow(workflow) => &workflow.line_index,
@@ -77,9 +72,12 @@ impl AuditInput {
     }
 }
 
-impl AsRef<Document> for AuditInput {
-    fn as_ref(&self) -> &Document {
-        self.document()
+impl<'a> AsDocument<'a, 'a> for AuditInput {
+    fn as_document(&'a self) -> &'a Document {
+        match self {
+            AuditInput::Workflow(workflow) => workflow.as_document(),
+            AuditInput::Action(action) => action.as_document(),
+        }
     }
 }
 

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -111,7 +111,7 @@ pub(crate) trait AuditCore {
     where
         Self: Sized;
 
-    fn finding<'w>() -> FindingBuilder<'w>
+    fn finding<'doc>() -> FindingBuilder<'doc>
     where
         Self: Sized,
     {
@@ -196,11 +196,11 @@ pub(crate) trait Audit: AuditCore {
     where
         Self: Sized;
 
-    fn audit_step<'w>(&self, _step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_step<'doc>(&self, _step: &Step<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
         Ok(vec![])
     }
 
-    fn audit_normal_job<'w>(&self, job: &NormalJob<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_normal_job<'doc>(&self, job: &NormalJob<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut results = vec![];
         for step in job.steps() {
             results.extend(self.audit_step(&step)?);
@@ -208,14 +208,14 @@ pub(crate) trait Audit: AuditCore {
         Ok(results)
     }
 
-    fn audit_reusable_job<'w>(
+    fn audit_reusable_job<'doc>(
         &self,
-        _job: &ReusableWorkflowCallJob<'w>,
-    ) -> anyhow::Result<Vec<Finding<'w>>> {
+        _job: &ReusableWorkflowCallJob<'doc>,
+    ) -> anyhow::Result<Vec<Finding<'doc>>> {
         Ok(vec![])
     }
 
-    fn audit_workflow<'w>(&self, workflow: &'w Workflow) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_workflow<'doc>(&self, workflow: &'doc Workflow) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut results = vec![];
 
         for job in workflow.jobs() {
@@ -232,14 +232,14 @@ pub(crate) trait Audit: AuditCore {
         Ok(results)
     }
 
-    fn audit_composite_step<'a>(
+    fn audit_composite_step<'doc>(
         &self,
-        _step: &CompositeStep<'a>,
-    ) -> anyhow::Result<Vec<Finding<'a>>> {
+        _step: &CompositeStep<'doc>,
+    ) -> anyhow::Result<Vec<Finding<'doc>>> {
         Ok(vec![])
     }
 
-    fn audit_action<'a>(&self, action: &'a Action) -> anyhow::Result<Vec<Finding<'a>>> {
+    fn audit_action<'doc>(&self, action: &'doc Action) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut results = vec![];
 
         if matches!(action.runs, action::Runs::Composite(_)) {
@@ -251,7 +251,7 @@ pub(crate) trait Audit: AuditCore {
         Ok(results)
     }
 
-    fn audit_raw<'w>(&self, _input: &'w AuditInput) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_raw<'doc>(&self, _input: &'doc AuditInput) -> anyhow::Result<Vec<Finding<'doc>>> {
         Ok(vec![])
     }
 
@@ -260,7 +260,7 @@ pub(crate) trait Audit: AuditCore {
     /// Implementors **should not** override this blanket implementation,
     /// since it's marked with tracing instrumentation.
     #[instrument(skip(self))]
-    fn audit<'w>(&self, input: &'w AuditInput) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit<'doc>(&self, input: &'doc AuditInput) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut results = match input {
             AuditInput::Workflow(workflow) => self.audit_workflow(workflow),
             AuditInput::Action(action) => self.audit_action(action),

--- a/src/audit/obfuscation.rs
+++ b/src/audit/obfuscation.rs
@@ -84,7 +84,7 @@ impl Obfuscation {
                                 .with_keys(&["uses".into()])
                                 .annotated(annotation),
                         )
-                        .build_with_document(step.document())?,
+                        .build(step)?,
                 );
             }
         }

--- a/src/audit/obfuscation.rs
+++ b/src/audit/obfuscation.rs
@@ -69,7 +69,10 @@ impl Obfuscation {
         annotations
     }
 
-    fn process_step<'w>(&self, step: &impl StepCommon<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn process_step<'doc>(
+        &self,
+        step: &impl StepCommon<'doc>,
+    ) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         if let Some(Uses::Repository(uses)) = step.uses() {
@@ -101,7 +104,7 @@ impl Audit for Obfuscation {
         Ok(Self)
     }
 
-    fn audit_raw<'w>(&self, input: &'w AuditInput) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_raw<'doc>(&self, input: &'doc AuditInput) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         for (expr, span) in parse_expressions_from_input(input) {
@@ -127,7 +130,7 @@ impl Audit for Obfuscation {
         Ok(findings)
     }
 
-    fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_step<'doc>(&self, step: &Step<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
         self.process_step(step)
     }
 

--- a/src/audit/overprovisioned_secrets.rs
+++ b/src/audit/overprovisioned_secrets.rs
@@ -22,7 +22,10 @@ impl Audit for OverprovisionedSecrets {
         Ok(Self)
     }
 
-    fn audit_raw<'w>(&self, input: &'w AuditInput) -> anyhow::Result<Vec<super::Finding<'w>>> {
+    fn audit_raw<'doc>(
+        &self,
+        input: &'doc AuditInput,
+    ) -> anyhow::Result<Vec<super::Finding<'doc>>> {
         let mut findings = vec![];
 
         for (expr, span) in parse_expressions_from_input(input) {

--- a/src/audit/ref_confusion.rs
+++ b/src/audit/ref_confusion.rs
@@ -67,10 +67,10 @@ impl Audit for RefConfusion {
         Ok(Self { client })
     }
 
-    fn audit_workflow<'w>(
+    fn audit_workflow<'doc>(
         &self,
-        workflow: &'w crate::models::Workflow,
-    ) -> anyhow::Result<Vec<crate::finding::Finding<'w>>> {
+        workflow: &'doc crate::models::Workflow,
+    ) -> anyhow::Result<Vec<crate::finding::Finding<'doc>>> {
         let mut findings = vec![];
 
         for job in workflow.jobs() {

--- a/src/audit/secrets_inherit.rs
+++ b/src/audit/secrets_inherit.rs
@@ -19,10 +19,10 @@ impl Audit for SecretsInherit {
         Ok(Self)
     }
 
-    fn audit_reusable_job<'w>(
+    fn audit_reusable_job<'doc>(
         &self,
-        job: &super::ReusableWorkflowCallJob<'w>,
-    ) -> anyhow::Result<Vec<super::Finding<'w>>> {
+        job: &super::ReusableWorkflowCallJob<'doc>,
+    ) -> anyhow::Result<Vec<super::Finding<'doc>>> {
         let mut findings = vec![];
 
         if matches!(job.secrets, Some(Secrets::Inherit)) {

--- a/src/audit/self_hosted_runner.rs
+++ b/src/audit/self_hosted_runner.rs
@@ -35,10 +35,10 @@ impl Audit for SelfHostedRunner {
         Ok(Self)
     }
 
-    fn audit_workflow<'w>(
+    fn audit_workflow<'doc>(
         &self,
-        workflow: &'w crate::models::Workflow,
-    ) -> Result<Vec<crate::finding::Finding<'w>>> {
+        workflow: &'doc crate::models::Workflow,
+    ) -> Result<Vec<crate::finding::Finding<'doc>>> {
         let mut results = vec![];
 
         for job in workflow.jobs() {

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -291,7 +291,7 @@ impl TemplateInjection {
                             "{expr} may expand into attacker-controllable code"
                         )),
                     )
-                    .build_with_document(step.document())?,
+                    .build(step)?,
             )
         }
 

--- a/src/audit/template_injection.rs
+++ b/src/audit/template_injection.rs
@@ -269,7 +269,10 @@ impl TemplateInjection {
         bad_expressions
     }
 
-    fn process_step<'w>(&self, step: &impl StepCommon<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn process_step<'doc>(
+        &self,
+        step: &impl StepCommon<'doc>,
+    ) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         let Some((script, script_loc)) = Self::script_with_location(step) else {
@@ -307,7 +310,7 @@ impl Audit for TemplateInjection {
         Ok(Self)
     }
 
-    fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_step<'doc>(&self, step: &Step<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
         self.process_step(step)
     }
 

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -85,7 +85,10 @@ impl UnpinnedUses {
         }
     }
 
-    fn process_step<'w>(&self, step: &impl StepCommon<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn process_step<'doc>(
+        &self,
+        step: &impl StepCommon<'doc>,
+    ) -> anyhow::Result<Vec<Finding<'doc>>> {
         let mut findings = vec![];
 
         let Some(uses) = step.uses() else {
@@ -129,7 +132,7 @@ impl Audit for UnpinnedUses {
         })
     }
 
-    fn audit_step<'w>(&self, step: &Step<'w>) -> anyhow::Result<Vec<Finding<'w>>> {
+    fn audit_step<'doc>(&self, step: &Step<'doc>) -> anyhow::Result<Vec<Finding<'doc>>> {
         self.process_step(step)
     }
 

--- a/src/audit/unpinned_uses.rs
+++ b/src/audit/unpinned_uses.rs
@@ -104,7 +104,7 @@ impl UnpinnedUses {
                             .with_keys(&["uses".into()])
                             .annotated(annotation),
                     )
-                    .build_with_document(step.document())?,
+                    .build(step)?,
             );
         };
 

--- a/src/audit/unredacted_secrets.rs
+++ b/src/audit/unredacted_secrets.rs
@@ -23,10 +23,10 @@ impl Audit for UnredactedSecrets {
         Ok(Self)
     }
 
-    fn audit_raw<'w>(
+    fn audit_raw<'doc>(
         &self,
-        input: &'w super::AuditInput,
-    ) -> anyhow::Result<Vec<crate::finding::Finding<'w>>> {
+        input: &'doc super::AuditInput,
+    ) -> anyhow::Result<Vec<crate::finding::Finding<'doc>>> {
         let mut findings = vec![];
 
         for (expr, span) in parse_expressions_from_input(input) {

--- a/src/audit/use_trusted_publishing.rs
+++ b/src/audit/use_trusted_publishing.rs
@@ -71,7 +71,10 @@ impl Audit for UseTrustedPublishing {
         Ok(Self)
     }
 
-    fn audit_step<'w>(&self, step: &super::Step<'w>) -> anyhow::Result<Vec<super::Finding<'w>>> {
+    fn audit_step<'doc>(
+        &self,
+        step: &super::Step<'doc>,
+    ) -> anyhow::Result<Vec<super::Finding<'doc>>> {
         let mut findings = vec![];
 
         let StepBody::Uses {

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -251,12 +251,7 @@ impl<'w> SymbolicLocation<'w> {
     }
 
     /// Concretize this `SymbolicLocation`, consuming it in the process.
-    pub(crate) fn concretize(
-        self,
-        document: &'w impl AsRef<yamlpath::Document>,
-    ) -> Result<Location<'w>> {
-        let document = document.as_ref();
-
+    pub(crate) fn concretize(self, document: &'w yamlpath::Document) -> Result<Location<'w>> {
         // If we don't have a path into the workflow, all
         // we have is the workflow itself.
         let feature = if self.route.components.is_empty() {
@@ -524,6 +519,13 @@ impl<'w> FindingBuilder<'w> {
     }
 
     pub(crate) fn build(self, document: &'w impl AsRef<yamlpath::Document>) -> Result<Finding<'w>> {
+        self.build_with_document(document.as_ref())
+    }
+
+    pub(crate) fn build_with_document(
+        self,
+        document: &'w yamlpath::Document,
+    ) -> Result<Finding<'w>> {
         let mut locations = self
             .locations
             .iter()

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -11,7 +11,7 @@ use terminal_link::Link;
 
 use crate::{
     audit::AuditInput,
-    models::{CompositeStep, JobExt, Step},
+    models::{AsDocument, CompositeStep, JobExt, Step},
     registry::InputKey,
 };
 
@@ -378,7 +378,7 @@ pub(crate) struct Feature<'w> {
 
 impl<'w> Feature<'w> {
     pub(crate) fn from_span(span: &Range<usize>, input: &'w AuditInput) -> Self {
-        let raw = input.document().source();
+        let raw = input.as_document().source();
         let start = TextSize::new(span.start as u32);
         let end = TextSize::new(span.end as u32);
 
@@ -518,18 +518,11 @@ impl<'w> FindingBuilder<'w> {
         self
     }
 
-    pub(crate) fn build(self, document: &'w impl AsRef<yamlpath::Document>) -> Result<Finding<'w>> {
-        self.build_with_document(document.as_ref())
-    }
-
-    pub(crate) fn build_with_document(
-        self,
-        document: &'w yamlpath::Document,
-    ) -> Result<Finding<'w>> {
+    pub(crate) fn build<'a>(self, document: &'a impl AsDocument<'a, 'w>) -> Result<Finding<'w>> {
         let mut locations = self
             .locations
             .iter()
-            .map(|l| l.clone().concretize(document))
+            .map(|l| l.clone().concretize(document.as_document()))
             .collect::<Result<Vec<_>>>()?;
 
         locations.extend(self.raw_locations);

--- a/src/finding/mod.rs
+++ b/src/finding/mod.rs
@@ -99,14 +99,14 @@ pub(crate) enum Severity {
 }
 
 #[derive(Serialize, Clone, Debug)]
-pub(crate) struct StepLocation<'w> {
+pub(crate) struct StepLocation<'doc> {
     pub(crate) index: usize,
-    pub(crate) id: Option<&'w str>,
-    pub(crate) name: Option<&'w str>,
+    pub(crate) id: Option<&'doc str>,
+    pub(crate) name: Option<&'doc str>,
 }
 
-impl<'w> From<&Step<'w>> for StepLocation<'w> {
-    fn from(step: &Step<'w>) -> Self {
+impl<'doc> From<&Step<'doc>> for StepLocation<'doc> {
+    fn from(step: &Step<'doc>) -> Self {
         Self {
             index: step.index,
             id: step.id.as_deref(),
@@ -116,8 +116,8 @@ impl<'w> From<&Step<'w>> for StepLocation<'w> {
 }
 
 #[derive(Serialize, Clone, Debug)]
-pub(crate) enum RouteComponent<'w> {
-    Key(Cow<'w, str>),
+pub(crate) enum RouteComponent<'doc> {
+    Key(Cow<'doc, str>),
     Index(usize),
 }
 
@@ -127,25 +127,25 @@ impl From<usize> for RouteComponent<'_> {
     }
 }
 
-impl<'w> From<&'w str> for RouteComponent<'w> {
-    fn from(value: &'w str) -> Self {
+impl<'doc> From<&'doc str> for RouteComponent<'doc> {
+    fn from(value: &'doc str) -> Self {
         Self::Key(Cow::Borrowed(value))
     }
 }
 
 #[derive(Serialize, Clone, Debug)]
-pub(crate) struct Route<'w> {
-    components: Vec<RouteComponent<'w>>,
+pub(crate) struct Route<'doc> {
+    components: Vec<RouteComponent<'doc>>,
 }
 
-impl<'w> Route<'w> {
-    pub(crate) fn new() -> Route<'w> {
+impl<'doc> Route<'doc> {
+    pub(crate) fn new() -> Route<'doc> {
         Self {
             components: Default::default(),
         }
     }
 
-    fn with_keys(&self, keys: &[RouteComponent<'w>]) -> Route<'w> {
+    fn with_keys(&self, keys: &[RouteComponent<'doc>]) -> Route<'doc> {
         let mut components = self.components.clone();
         components.extend(keys.iter().cloned());
         Route { components }
@@ -175,9 +175,9 @@ pub(crate) enum LocationKind {
 
 /// Represents a symbolic location.
 #[derive(Serialize, Clone, Debug)]
-pub(crate) struct SymbolicLocation<'w> {
+pub(crate) struct SymbolicLocation<'doc> {
     /// The unique ID of the input, as it appears in the input registry.
-    pub(crate) key: &'w InputKey,
+    pub(crate) key: &'doc InputKey,
 
     /// An annotation for this location.
     pub(crate) annotation: String,
@@ -189,14 +189,14 @@ pub(crate) struct SymbolicLocation<'w> {
     pub(crate) link: Option<String>,
 
     /// A symbolic route (of keys and indices) to the final location.
-    pub(crate) route: Route<'w>,
+    pub(crate) route: Route<'doc>,
 
     /// The kind of location.
     pub(crate) kind: LocationKind,
 }
 
-impl<'w> SymbolicLocation<'w> {
-    pub(crate) fn with_keys(&self, keys: &[RouteComponent<'w>]) -> SymbolicLocation<'w> {
+impl<'doc> SymbolicLocation<'doc> {
+    pub(crate) fn with_keys(&self, keys: &[RouteComponent<'doc>]) -> SymbolicLocation<'doc> {
         SymbolicLocation {
             key: self.key,
             annotation: self.annotation.clone(),
@@ -206,38 +206,38 @@ impl<'w> SymbolicLocation<'w> {
         }
     }
 
-    pub(crate) fn with_job(&self, job: &impl JobExt<'w>) -> SymbolicLocation<'w> {
+    pub(crate) fn with_job(&self, job: &impl JobExt<'doc>) -> SymbolicLocation<'doc> {
         self.with_keys(&["jobs".into(), job.id().into()])
     }
 
-    pub(crate) fn with_step(&self, step: &Step<'w>) -> SymbolicLocation<'w> {
+    pub(crate) fn with_step(&self, step: &Step<'doc>) -> SymbolicLocation<'doc> {
         self.with_keys(&["steps".into(), step.index.into()])
     }
 
-    pub(crate) fn with_composite_step(&self, step: &CompositeStep<'w>) -> SymbolicLocation<'w> {
+    pub(crate) fn with_composite_step(&self, step: &CompositeStep<'doc>) -> SymbolicLocation<'doc> {
         self.with_keys(&["runs".into(), "steps".into(), step.index.into()])
     }
 
     /// Adds a human-readable annotation to the current `SymbolicLocation`.
-    pub(crate) fn annotated(mut self, annotation: impl Into<String>) -> SymbolicLocation<'w> {
+    pub(crate) fn annotated(mut self, annotation: impl Into<String>) -> SymbolicLocation<'doc> {
         self.annotation = annotation.into();
         self
     }
 
     /// Adds a URL to the current `SymbolicLocation`.
-    pub(crate) fn with_url(mut self, url: impl Into<String>) -> SymbolicLocation<'w> {
+    pub(crate) fn with_url(mut self, url: impl Into<String>) -> SymbolicLocation<'doc> {
         self.link = Some(Link::new(&self.annotation, &url.into()).to_string());
         self
     }
 
     /// Mark the current `SymbolicLocation` as a "primary" location.
-    pub(crate) fn primary(mut self) -> SymbolicLocation<'w> {
+    pub(crate) fn primary(mut self) -> SymbolicLocation<'doc> {
         self.kind = LocationKind::Primary;
         self
     }
 
     /// Mark the current `SymbolicLocation` as a "hidden" location.
-    pub(crate) fn hidden(mut self) -> SymbolicLocation<'w> {
+    pub(crate) fn hidden(mut self) -> SymbolicLocation<'doc> {
         self.kind = LocationKind::Hidden;
         self
     }
@@ -251,7 +251,7 @@ impl<'w> SymbolicLocation<'w> {
     }
 
     /// Concretize this `SymbolicLocation`, consuming it in the process.
-    pub(crate) fn concretize(self, document: &'w yamlpath::Document) -> Result<Location<'w>> {
+    pub(crate) fn concretize(self, document: &'doc yamlpath::Document) -> Result<Location<'doc>> {
         // If we don't have a path into the workflow, all
         // we have is the workflow itself.
         let feature = if self.route.components.is_empty() {
@@ -346,7 +346,7 @@ static IGNORE_EXPR: LazyLock<Regex> =
 /// Represents a single source comment.
 #[derive(Debug, Serialize)]
 #[serde(transparent)]
-pub(crate) struct Comment<'w>(&'w str);
+pub(crate) struct Comment<'doc>(&'doc str);
 
 impl Comment<'_> {
     fn ignores(&self, rule_id: &str) -> bool {
@@ -365,19 +365,19 @@ impl Comment<'_> {
 
 /// An extracted feature, along with its concrete location.
 #[derive(Serialize)]
-pub(crate) struct Feature<'w> {
+pub(crate) struct Feature<'doc> {
     /// The feature's concrete location, as both an offset range and point span.
     pub(crate) location: ConcreteLocation,
 
     /// The feature's textual content.
-    pub(crate) feature: &'w str,
+    pub(crate) feature: &'doc str,
 
     /// Any comments within the feature's line span.
-    pub(crate) comments: Vec<Comment<'w>>,
+    pub(crate) comments: Vec<Comment<'doc>>,
 }
 
-impl<'w> Feature<'w> {
-    pub(crate) fn from_span(span: &Range<usize>, input: &'w AuditInput) -> Self {
+impl<'doc> Feature<'doc> {
+    pub(crate) fn from_span(span: &Range<usize>, input: &'doc AuditInput) -> Self {
         let raw = input.as_document().source();
         let start = TextSize::new(span.start as u32);
         let end = TextSize::new(span.end as u32);
@@ -421,15 +421,15 @@ impl<'w> Feature<'w> {
 
 /// A location within a GitHub Actions workflow, with both symbolic and concrete components.
 #[derive(Serialize)]
-pub(crate) struct Location<'w> {
+pub(crate) struct Location<'doc> {
     /// The symbolic workflow location.
-    pub(crate) symbolic: SymbolicLocation<'w>,
+    pub(crate) symbolic: SymbolicLocation<'doc>,
     /// The concrete location, including extracted feature.
-    pub(crate) concrete: Feature<'w>,
+    pub(crate) concrete: Feature<'doc>,
 }
 
-impl<'w> Location<'w> {
-    pub(crate) fn new(symbolic: SymbolicLocation<'w>, concrete: Feature<'w>) -> Self {
+impl<'doc> Location<'doc> {
+    pub(crate) fn new(symbolic: SymbolicLocation<'doc>, concrete: Feature<'doc>) -> Self {
         Self { symbolic, concrete }
     }
 }
@@ -443,12 +443,12 @@ pub(crate) struct Determinations {
 }
 
 #[derive(Serialize)]
-pub(crate) struct Finding<'w> {
+pub(crate) struct Finding<'doc> {
     pub(crate) ident: &'static str,
     pub(crate) desc: &'static str,
     pub(crate) url: &'static str,
     pub(crate) determinations: Determinations,
-    pub(crate) locations: Vec<Location<'w>>,
+    pub(crate) locations: Vec<Location<'doc>>,
     pub(crate) ignored: bool,
 }
 
@@ -468,18 +468,18 @@ impl Finding<'_> {
     }
 }
 
-pub(crate) struct FindingBuilder<'w> {
+pub(crate) struct FindingBuilder<'doc> {
     ident: &'static str,
     desc: &'static str,
     url: &'static str,
     severity: Severity,
     confidence: Confidence,
     persona: Persona,
-    raw_locations: Vec<Location<'w>>,
-    locations: Vec<SymbolicLocation<'w>>,
+    raw_locations: Vec<Location<'doc>>,
+    locations: Vec<SymbolicLocation<'doc>>,
 }
 
-impl<'w> FindingBuilder<'w> {
+impl<'doc> FindingBuilder<'doc> {
     pub(crate) fn new(ident: &'static str, desc: &'static str, url: &'static str) -> Self {
         Self {
             ident,
@@ -508,17 +508,20 @@ impl<'w> FindingBuilder<'w> {
         self
     }
 
-    pub(crate) fn add_raw_location(mut self, location: Location<'w>) -> Self {
+    pub(crate) fn add_raw_location(mut self, location: Location<'doc>) -> Self {
         self.raw_locations.push(location);
         self
     }
 
-    pub(crate) fn add_location(mut self, location: SymbolicLocation<'w>) -> Self {
+    pub(crate) fn add_location(mut self, location: SymbolicLocation<'doc>) -> Self {
         self.locations.push(location);
         self
     }
 
-    pub(crate) fn build<'a>(self, document: &'a impl AsDocument<'a, 'w>) -> Result<Finding<'w>> {
+    pub(crate) fn build<'a>(
+        self,
+        document: &'a impl AsDocument<'a, 'doc>,
+    ) -> Result<Finding<'doc>> {
         let mut locations = self
             .locations
             .iter()

--- a/src/models.rs
+++ b/src/models.rs
@@ -67,6 +67,16 @@ pub(crate) trait StepCommon<'s> {
     fn document(&self) -> &'s yamlpath::Document;
 }
 
+pub(crate) trait AsDocument<'a, 'doc> {
+    fn as_document(&'a self) -> &'doc yamlpath::Document;
+}
+
+impl<'a, 'doc, T: StepCommon<'doc>> AsDocument<'a, 'doc> for T {
+    fn as_document(&'a self) -> &'doc yamlpath::Document {
+        self.document()
+    }
+}
+
 /// Represents an entire GitHub Actions workflow.
 ///
 /// This type implements [`Deref`] for [`workflow::Workflow`],
@@ -79,6 +89,12 @@ pub(crate) struct Workflow {
     pub(crate) document: yamlpath::Document,
     pub(crate) line_index: LineIndex,
     inner: workflow::Workflow,
+}
+
+impl<'a> AsDocument<'a, 'a> for Workflow {
+    fn as_document(&'a self) -> &'a yamlpath::Document {
+        &self.document
+    }
 }
 
 impl AsRef<yamlpath::Document> for Workflow {
@@ -722,8 +738,8 @@ pub(crate) struct Action {
     inner: action::Action,
 }
 
-impl AsRef<yamlpath::Document> for Action {
-    fn as_ref(&self) -> &yamlpath::Document {
+impl<'a> AsDocument<'a, 'a> for Action {
+    fn as_document(&'a self) -> &'a yamlpath::Document {
         &self.document
     }
 }
@@ -903,7 +919,7 @@ impl<'s> StepCommon<'s> for CompositeStep<'s> {
     }
 
     fn document(&self) -> &'s yamlpath::Document {
-        self.action().as_ref()
+        self.action().as_document()
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -97,12 +97,6 @@ impl<'a> AsDocument<'a, 'a> for Workflow {
     }
 }
 
-impl AsRef<yamlpath::Document> for Workflow {
-    fn as_ref(&self) -> &yamlpath::Document {
-        &self.document
-    }
-}
-
 impl Debug for Workflow {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{key}", key = self.key)
@@ -635,7 +629,7 @@ impl<'doc> StepCommon<'doc> for Step<'doc> {
     }
 
     fn document(&self) -> &'doc yamlpath::Document {
-        self.workflow().as_ref()
+        self.workflow().as_document()
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -204,35 +204,35 @@ impl Workflow {
 }
 
 /// Common behavior across both normal and reusable jobs.
-pub(crate) trait JobExt<'w> {
+pub(crate) trait JobExt<'doc> {
     /// The job's unique ID (i.e., its key in the workflow's `jobs:` block).
-    fn id(&self) -> &'w str;
+    fn id(&self) -> &'doc str;
 
     /// The job's symbolic location.
-    fn location(&self) -> SymbolicLocation<'w>;
+    fn location(&self) -> SymbolicLocation<'doc>;
 
     /// The job's parent [`Workflow`].
-    fn parent(&self) -> &'w Workflow;
+    fn parent(&self) -> &'doc Workflow;
 }
 
 /// Represents a single "normal" GitHub Actions job.
 #[derive(Clone)]
-pub(crate) struct NormalJob<'w> {
+pub(crate) struct NormalJob<'doc> {
     /// The job's unique ID (i.e., its key in the workflow's `jobs:` block).
-    id: &'w str,
+    id: &'doc str,
     /// The underlying job.
-    inner: &'w job::NormalJob,
+    inner: &'doc job::NormalJob,
     /// The job's parent [`Workflow`].
-    parent: &'w Workflow,
+    parent: &'doc Workflow,
 }
 
-impl<'w> NormalJob<'w> {
-    pub(crate) fn new(id: &'w str, inner: &'w job::NormalJob, parent: &'w Workflow) -> Self {
+impl<'doc> NormalJob<'doc> {
+    pub(crate) fn new(id: &'doc str, inner: &'doc job::NormalJob, parent: &'doc Workflow) -> Self {
         Self { id, inner, parent }
     }
 
     /// An iterator of this job's constituent [`Step`]s.
-    pub(crate) fn steps(&self) -> Steps<'w> {
+    pub(crate) fn steps(&self) -> Steps<'doc> {
         Steps::new(self)
     }
 
@@ -267,25 +267,25 @@ impl<'w> NormalJob<'w> {
     }
 }
 
-impl<'w> JobExt<'w> for NormalJob<'w> {
-    fn id(&self) -> &'w str {
+impl<'doc> JobExt<'doc> for NormalJob<'doc> {
+    fn id(&self) -> &'doc str {
         self.id
     }
 
-    fn location(&self) -> SymbolicLocation<'w> {
+    fn location(&self) -> SymbolicLocation<'doc> {
         self.parent()
             .location()
             .annotated("this job")
             .with_job(self)
     }
 
-    fn parent(&self) -> &'w Workflow {
+    fn parent(&self) -> &'doc Workflow {
         self.parent
     }
 }
 
-impl<'w> Deref for NormalJob<'w> {
-    type Target = &'w job::NormalJob;
+impl<'doc> Deref for NormalJob<'doc> {
+    type Target = &'doc job::NormalJob;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
@@ -294,44 +294,44 @@ impl<'w> Deref for NormalJob<'w> {
 
 /// Represents a reusable workflow call job.
 #[derive(Clone)]
-pub(crate) struct ReusableWorkflowCallJob<'w> {
+pub(crate) struct ReusableWorkflowCallJob<'doc> {
     /// The job's unique ID (i.e., its key in the workflow's `jobs:` block).
-    id: &'w str,
+    id: &'doc str,
     /// The underlying job.
-    inner: &'w job::ReusableWorkflowCallJob,
+    inner: &'doc job::ReusableWorkflowCallJob,
     /// The job's parent [`Workflow`].
-    parent: &'w Workflow,
+    parent: &'doc Workflow,
 }
 
-impl<'w> ReusableWorkflowCallJob<'w> {
+impl<'doc> ReusableWorkflowCallJob<'doc> {
     pub(crate) fn new(
-        id: &'w str,
-        inner: &'w job::ReusableWorkflowCallJob,
-        parent: &'w Workflow,
+        id: &'doc str,
+        inner: &'doc job::ReusableWorkflowCallJob,
+        parent: &'doc Workflow,
     ) -> Self {
         Self { id, inner, parent }
     }
 }
 
-impl<'w> JobExt<'w> for ReusableWorkflowCallJob<'w> {
-    fn id(&self) -> &'w str {
+impl<'doc> JobExt<'doc> for ReusableWorkflowCallJob<'doc> {
+    fn id(&self) -> &'doc str {
         self.id
     }
 
-    fn location(&self) -> SymbolicLocation<'w> {
+    fn location(&self) -> SymbolicLocation<'doc> {
         self.parent()
             .location()
             .annotated("this job")
             .with_job(self)
     }
 
-    fn parent(&self) -> &'w Workflow {
+    fn parent(&self) -> &'doc Workflow {
         self.parent
     }
 }
 
-impl<'w> Deref for ReusableWorkflowCallJob<'w> {
-    type Target = &'w job::ReusableWorkflowCallJob;
+impl<'doc> Deref for ReusableWorkflowCallJob<'doc> {
+    type Target = &'doc job::ReusableWorkflowCallJob;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
@@ -340,13 +340,13 @@ impl<'w> Deref for ReusableWorkflowCallJob<'w> {
 
 /// Represents a single GitHub Actions job.
 #[derive(Clone)]
-pub(crate) enum Job<'w> {
-    NormalJob(NormalJob<'w>),
-    ReusableWorkflowCallJob(ReusableWorkflowCallJob<'w>),
+pub(crate) enum Job<'doc> {
+    NormalJob(NormalJob<'doc>),
+    ReusableWorkflowCallJob(ReusableWorkflowCallJob<'doc>),
 }
 
-impl<'w> Job<'w> {
-    fn new(id: &'w str, inner: &'w workflow::Job, parent: &'w Workflow) -> Self {
+impl<'doc> Job<'doc> {
+    fn new(id: &'doc str, inner: &'doc workflow::Job, parent: &'doc Workflow) -> Self {
         match inner {
             workflow::Job::NormalJob(normal) => Job::NormalJob(NormalJob::new(id, normal, parent)),
             workflow::Job::ReusableWorkflowCallJob(reusable) => {
@@ -357,13 +357,13 @@ impl<'w> Job<'w> {
 }
 
 /// An iterable container for jobs within a [`Workflow`].
-pub(crate) struct Jobs<'w> {
-    parent: &'w Workflow,
-    inner: indexmap::map::Iter<'w, String, workflow::Job>,
+pub(crate) struct Jobs<'doc> {
+    parent: &'doc Workflow,
+    inner: indexmap::map::Iter<'doc, String, workflow::Job>,
 }
 
-impl<'w> Jobs<'w> {
-    fn new(workflow: &'w Workflow) -> Self {
+impl<'doc> Jobs<'doc> {
+    fn new(workflow: &'doc Workflow) -> Self {
         Self {
             parent: workflow,
             inner: workflow.jobs.iter(),
@@ -371,8 +371,8 @@ impl<'w> Jobs<'w> {
     }
 }
 
-impl<'w> Iterator for Jobs<'w> {
-    type Item = Job<'w>;
+impl<'doc> Iterator for Jobs<'doc> {
+    type Item = Job<'doc>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let item = self.inner.next();
@@ -389,23 +389,23 @@ impl<'w> Iterator for Jobs<'w> {
 /// This type implements [`Deref`] for [`job::NormalJob::strategy`], providing
 /// access to the underlying data model.
 #[derive(Clone)]
-pub(crate) struct Matrix<'w> {
-    inner: &'w LoE<job::Matrix>,
+pub(crate) struct Matrix<'doc> {
+    inner: &'doc LoE<job::Matrix>,
     pub(crate) expanded_values: Vec<(String, String)>,
 }
 
-impl<'w> Deref for Matrix<'w> {
-    type Target = &'w LoE<job::Matrix>;
+impl<'doc> Deref for Matrix<'doc> {
+    type Target = &'doc LoE<job::Matrix>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl<'w> TryFrom<&'w NormalJob<'w>> for Matrix<'w> {
+impl<'doc> TryFrom<&'doc NormalJob<'doc>> for Matrix<'doc> {
     type Error = anyhow::Error;
 
-    fn try_from(job: &'w NormalJob<'w>) -> std::result::Result<Self, Self::Error> {
+    fn try_from(job: &'doc NormalJob<'doc>) -> std::result::Result<Self, Self::Error> {
         let Some(Strategy {
             matrix: Some(inner),
             ..
@@ -418,8 +418,8 @@ impl<'w> TryFrom<&'w NormalJob<'w>> for Matrix<'w> {
     }
 }
 
-impl<'w> Matrix<'w> {
-    pub(crate) fn new(inner: &'w LoE<job::Matrix>) -> Self {
+impl<'doc> Matrix<'doc> {
+    pub(crate) fn new(inner: &'doc LoE<job::Matrix>) -> Self {
         Self {
             inner,
             expanded_values: Matrix::expand_values(inner),
@@ -549,24 +549,24 @@ impl<'w> Matrix<'w> {
 /// This type implements [`Deref`] for [`workflow::job::Step`], which
 /// provides access to the step's actual fields.
 #[derive(Clone)]
-pub(crate) struct Step<'w> {
+pub(crate) struct Step<'doc> {
     /// The step's index within its parent job.
     pub(crate) index: usize,
     /// The inner step model.
-    inner: &'w workflow::job::Step,
+    inner: &'doc workflow::job::Step,
     /// The parent [`Job`].
-    pub(crate) parent: NormalJob<'w>,
+    pub(crate) parent: NormalJob<'doc>,
 }
 
-impl<'w> Deref for Step<'w> {
-    type Target = &'w workflow::job::Step;
+impl<'doc> Deref for Step<'doc> {
+    type Target = &'doc workflow::job::Step;
 
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl<'s> StepCommon<'s> for Step<'s> {
+impl<'doc> StepCommon<'doc> for Step<'doc> {
     fn env_is_static(&self, name: &str) -> bool {
         // Collect each of the step, job, and workflow-level `env` blocks
         // and check each.
@@ -619,14 +619,14 @@ impl<'s> StepCommon<'s> for Step<'s> {
         }
     }
 
-    fn location(&self) -> SymbolicLocation<'s> {
+    fn location(&self) -> SymbolicLocation<'doc> {
         self.parent
             .location()
             .with_step(self)
             .annotated("this step")
     }
 
-    fn location_with_name(&self) -> SymbolicLocation<'s> {
+    fn location_with_name(&self) -> SymbolicLocation<'doc> {
         match self.inner.name {
             Some(_) => self.location().with_keys(&["name".into()]),
             None => self.location(),
@@ -634,13 +634,13 @@ impl<'s> StepCommon<'s> for Step<'s> {
         .annotated("this step")
     }
 
-    fn document(&self) -> &'s yamlpath::Document {
+    fn document(&self) -> &'doc yamlpath::Document {
         self.workflow().as_ref()
     }
 }
 
-impl<'w> Step<'w> {
-    fn new(index: usize, inner: &'w workflow::job::Step, parent: NormalJob<'w>) -> Self {
+impl<'doc> Step<'doc> {
+    fn new(index: usize, inner: &'doc workflow::job::Step, parent: NormalJob<'doc>) -> Self {
         Self {
             index,
             inner,
@@ -649,12 +649,12 @@ impl<'w> Step<'w> {
     }
 
     /// Returns this step's parent [`NormalJob`].
-    pub(crate) fn job(&self) -> &NormalJob<'w> {
+    pub(crate) fn job(&self) -> &NormalJob<'doc> {
         &self.parent
     }
 
     /// Returns this step's (grand)parent [`Workflow`].
-    pub(crate) fn workflow(&self) -> &'w Workflow {
+    pub(crate) fn workflow(&self) -> &'doc Workflow {
         self.parent.parent()
     }
 
@@ -697,14 +697,14 @@ impl<'w> Step<'w> {
 }
 
 /// An iterable container for steps within a [`Job`].
-pub(crate) struct Steps<'w> {
-    inner: Enumerate<std::slice::Iter<'w, github_actions_models::workflow::job::Step>>,
-    parent: NormalJob<'w>,
+pub(crate) struct Steps<'doc> {
+    inner: Enumerate<std::slice::Iter<'doc, github_actions_models::workflow::job::Step>>,
+    parent: NormalJob<'doc>,
 }
 
-impl<'w> Steps<'w> {
+impl<'doc> Steps<'doc> {
     /// Create a new [`Steps`].
-    fn new(job: &NormalJob<'w>) -> Self {
+    fn new(job: &NormalJob<'doc>) -> Self {
         Self {
             inner: job.steps.iter().enumerate(),
             parent: job.clone(),
@@ -712,8 +712,8 @@ impl<'w> Steps<'w> {
     }
 }
 
-impl<'w> Iterator for Steps<'w> {
-    type Item = Step<'w>;
+impl<'doc> Iterator for Steps<'doc> {
+    type Item = Step<'doc>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let item = self.inner.next();

--- a/src/models.rs
+++ b/src/models.rs
@@ -62,6 +62,9 @@ pub(crate) trait StepCommon<'s> {
     /// Like [`Self::location()`], except with the step's `name`
     /// key as the final path component if present.
     fn location_with_name(&self) -> SymbolicLocation<'s>;
+
+    /// Returns the document which contains this step.
+    fn document(&self) -> &'s yamlpath::Document;
 }
 
 /// Represents an entire GitHub Actions workflow.
@@ -614,6 +617,10 @@ impl<'s> StepCommon<'s> for Step<'s> {
         }
         .annotated("this step")
     }
+
+    fn document(&self) -> &'s yamlpath::Document {
+        self.workflow().as_ref()
+    }
 }
 
 impl<'w> Step<'w> {
@@ -893,6 +900,10 @@ impl<'s> StepCommon<'s> for CompositeStep<'s> {
             None => self.location(),
         }
         .annotated("this step")
+    }
+
+    fn document(&self) -> &'s yamlpath::Document {
+        self.action().as_ref()
     }
 }
 

--- a/src/models/coordinate.rs
+++ b/src/models/coordinate.rs
@@ -368,6 +368,10 @@ mod tests {
         fn location_with_name(&self) -> crate::finding::SymbolicLocation<'s> {
             unimplemented!()
         }
+
+        fn document(&self) -> &'s yamlpath::Document {
+            unimplemented!()
+        }
     }
 
     #[test]

--- a/src/output/plain.rs
+++ b/src/output/plain.rs
@@ -26,13 +26,13 @@ impl From<&Severity> for Level {
     }
 }
 
-pub(crate) fn finding_snippet<'w>(
-    registry: &'w InputRegistry,
-    finding: &'w Finding<'w>,
-) -> Vec<Snippet<'w>> {
+pub(crate) fn finding_snippet<'doc>(
+    registry: &'doc InputRegistry,
+    finding: &'doc Finding<'doc>,
+) -> Vec<Snippet<'doc>> {
     // Our finding might span multiple workflows, so we need to group locations
     // by their enclosing workflow to generate each snippet correctly.
-    let mut locations_by_workflow: HashMap<&InputKey, Vec<&Location<'w>>> = HashMap::new();
+    let mut locations_by_workflow: HashMap<&InputKey, Vec<&Location<'doc>>> = HashMap::new();
     for location in &finding.locations {
         // Never include hidden locations in the output.
         if location.symbolic.is_hidden() {

--- a/src/output/plain.rs
+++ b/src/output/plain.rs
@@ -10,6 +10,7 @@ use terminal_link::Link;
 use crate::{
     App,
     finding::{Finding, Location, Severity},
+    models::AsDocument,
     registry::{FindingRegistry, InputKey, InputRegistry},
 };
 
@@ -53,7 +54,7 @@ pub(crate) fn finding_snippet<'w>(
         let input = registry.get_input(input_key);
 
         snippets.push(
-            Snippet::source(input.document().source())
+            Snippet::source(input.as_document().source())
                 .fold(true)
                 .line_start(1)
                 .origin(input.link().unwrap_or(input_key.presentation_path()))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ use github_actions_models::common::{
     expr::{ExplicitExpr, LoE},
 };
 
-use crate::audit::AuditInput;
+use crate::{audit::AuditInput, models::AsDocument};
 
 /// Convenience trait for inline transformations of `Self`.
 ///
@@ -100,8 +100,8 @@ pub(crate) fn extract_expressions(text: &str) -> Vec<(ExplicitExpr, Range<usize>
 pub(crate) fn parse_expressions_from_input(
     input: &AuditInput,
 ) -> Vec<(ExplicitExpr, Range<usize>)> {
-    let text = input.document().source();
-    let doc = input.document();
+    let text = input.as_document().source();
+    let doc = input.as_document();
 
     let mut exprs = vec![];
     let mut offset = 0;


### PR DESCRIPTION
Follow-up for #697

I was able to implement this now by having the new `document()` method return `&'s yamlpath::Document`[^1] instead of `&'s impl AsRef<yamlpath::Document>`, since for the latter the Rust compiler wanted explicit lifetimes at the callsites of `document()`, and I could not get that to work.

(Though if you know a way to make this work with `impl AsRef<...>` or similar, that would probably be even better.)


[^1]: Actually using  `&'s yamlpath::Document` was suggested by Copilot, though it still need some manual work to make it compile. Maybe it just chose the more straight forward approach without really understanding the effects, and I was just so fixated on using `impl AsRef<...>`.