### PR TITLE
bugfix: sarif: prefix ID, add rule names

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -15,6 +15,15 @@ of `zizmor`.
   GitHub Actions usages. These patterns are not themselves dangerous,
   but may indicate an attempt to obscure malicious behavior (#683)
 
+### Bug Fixes 🐛
+
+* The SARIF output format now uses `zizmor/{id}` for rule IDs instead
+  of bare IDs, reducing the chance of conflict or confusion with other tools
+  (#710)
+* The SARIF output format now includes a rule name for each rule descriptor,
+  which should improve rendering behavior in SARIF viewers like the
+  VS Code SARIF Viewer extension (#710)
+
 ## v1.6.0
 
 ### New Features 🌈

--- a/src/output/sarif.rs
+++ b/src/output/sarif.rs
@@ -80,7 +80,8 @@ fn build_rules(findings: &[Finding]) -> Vec<ReportingDescriptor> {
 
 fn build_rule(finding: &Finding) -> ReportingDescriptor {
     ReportingDescriptor::builder()
-        .id(finding.ident)
+        .id(format!("zizmor/{id}", id = finding.ident))
+        .name(finding.ident)
         .help_uri(finding.url)
         .help(
             MultiformatMessageString::builder()
@@ -104,7 +105,7 @@ fn build_result(finding: &Finding<'_>) -> SarifResult {
         .unwrap();
 
     SarifResult::builder()
-        .rule_id(finding.ident)
+        .rule_id(format!("zizmor/{id}", id = finding.ident))
         // NOTE: We use the primary location's annotation for the result's message.
         // This is conceptually incorrect since the location's annotation should
         // only be on the location itself. However, GitHub's SARIF viewer does not


### PR DESCRIPTION
This changes the SARIF rule ID to `zizmor/{id}` and adds a name to each rule descriptor, since not all tools fall back to the ID (specifically, VS Code's SARIF viewer appears to fail to do this).

Closes #622.
Fixes #709.