### PR TITLE
test: update snapshot expressions

### DIFF
--- a/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
+++ b/tests/integration/snapshots/integration__e2e__gha_hazmat.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/e2e.rs
 expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--no-online-audits\"]).input(\"woodruffw/gha-hazmat@42064a9533f401a493c3599e56f144918f8eacfd\").run()?"
-snapshot_kind: text
 ---
  INFO collect_inputs: zizmor: collected 20 inputs from woodruffw/gha-hazmat
  INFO zizmor: skipping impostor-commit: offline audits only requested

--- a/tests/integration/snapshots/integration__e2e__invalid_config_file.snap
+++ b/tests/integration/snapshots/integration__e2e__invalid_config_file.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/e2e.rs
-expression: "zizmor().output(OutputMode::Stderr).config(\"/dev/null\").input(input_under_test(\"e2e-menagerie\")).run()?"
-snapshot_kind: text
+expression: "zizmor().expects_failure(true).config(if cfg!(windows) { \"NUL\" } else\n{ \"/dev/null\" }).input(input_under_test(\"e2e-menagerie\")).run()?"
 ---
 fatal: no audit was performed
 error: failed to load config: missing field `rules`

--- a/tests/integration/snapshots/integration__e2e__menagerie-2.snap
+++ b/tests/integration/snapshots/integration__e2e__menagerie-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/e2e.rs
 expression: "zizmor().output(OutputMode::Both).args([\"--collect=all\"]).input(input_under_test(\"e2e-menagerie\")).run()?"
-snapshot_kind: text
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/tests/integration/snapshots/integration__e2e__menagerie.snap
+++ b/tests/integration/snapshots/integration__e2e__menagerie.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/e2e.rs
 expression: "zizmor().output(OutputMode::Both).input(input_under_test(\"e2e-menagerie\")).run()?"
-snapshot_kind: text
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/tests/integration/snapshots/integration__snapshot__artipacked-2.snap
+++ b/tests/integration/snapshots/integration__snapshot__artipacked-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"artipacked.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"artipacked.yml\")).run()?"
 ---
 warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> @@INPUT@@:15:9

--- a/tests/integration/snapshots/integration__snapshot__artipacked-3.snap
+++ b/tests/integration/snapshots/integration__snapshot__artipacked-3.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"artipacked.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"artipacked.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> @@INPUT@@:15:9

--- a/tests/integration/snapshots/integration__snapshot__artipacked-4.snap
+++ b/tests/integration/snapshots/integration__snapshot__artipacked-4.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"artipacked/issue-447-repro.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"artipacked/issue-447-repro.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> @@INPUT@@:19:9

--- a/tests/integration/snapshots/integration__snapshot__artipacked.snap
+++ b/tests/integration/snapshots/integration__snapshot__artipacked.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"artipacked.yml\")).args([\"--persona=pedantic\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"artipacked.yml\")).args([\"--persona=pedantic\"]).run()?"
 ---
 warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> @@INPUT@@:15:9

--- a/tests/integration/snapshots/integration__snapshot__bot_conditions.snap
+++ b/tests/integration/snapshots/integration__snapshot__bot_conditions.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"bot-conditions.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"bot-conditions.yml\")).run()?"
 ---
 error[dangerous-triggers]: use of fundamentally insecure workflow trigger
  --> @@INPUT@@:1:1

--- a/tests/integration/snapshots/integration__snapshot__cache_poisoning-11.snap
+++ b/tests/integration/snapshots/integration__snapshot__cache_poisoning-11.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"cache-poisoning/issue-343-repro.yml\")).run()?"
-snapshot_kind: text
 ---
 error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> @@INPUT@@:5:1

--- a/tests/integration/snapshots/integration__snapshot__cache_poisoning-3.snap
+++ b/tests/integration/snapshots/integration__snapshot__cache_poisoning-3.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"cache-poisoning/caching-opt-in-boolean-toggle.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"cache-poisoning/caching-opt-in-boolean-toggle.yml\")).run()?"
 ---
 error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> @@INPUT@@:1:1

--- a/tests/integration/snapshots/integration__snapshot__cache_poisoning-5.snap
+++ b/tests/integration/snapshots/integration__snapshot__cache_poisoning-5.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"cache-poisoning/caching-opt-in-multi-value-toggle.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"cache-poisoning/caching-opt-in-multi-value-toggle.yml\")).run()?"
 ---
 error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
   --> @@INPUT@@:1:1

--- a/tests/integration/snapshots/integration__snapshot__cache_poisoning-7.snap
+++ b/tests/integration/snapshots/integration__snapshot__cache_poisoning-7.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"cache-poisoning/no-cache-aware-steps.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"cache-poisoning/no-cache-aware-steps.yml\")).run()?"
 ---
 No findings to report. Good job!

--- a/tests/integration/snapshots/integration__snapshot__cache_poisoning.snap
+++ b/tests/integration/snapshots/integration__snapshot__cache_poisoning.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"cache-poisoning/caching-disabled-by-default.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"cache-poisoning/caching-disabled-by-default.yml\")).run()?"
 ---
 No findings to report. Good job!

--- a/tests/integration/snapshots/integration__snapshot__cant_retrieve.snap
+++ b/tests/integration/snapshots/integration__snapshot__cant_retrieve.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().output(OutputMode::Stderr).offline(true).unsetenv(\"GH_TOKEN\").args([\"pypa/sampleproject\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().expects_failure(true).offline(true).unsetenv(\"GH_TOKEN\").args([\"pypa/sampleproject\"]).run()?"
 ---
 fatal: no audit was performed
 error: can't retrieve repository: pypa/sampleproject

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-10.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-10.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/issue-472-repro.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/issue-472-repro.yml\")).run()?"
 ---
 warning[excessive-permissions]: overly broad permissions
   --> @@INPUT@@:19:3

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-11.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-11.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/reusable-workflow-call.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/reusable-workflow-call.yml\")).run()?"
 ---
 warning[excessive-permissions]: overly broad permissions
  --> @@INPUT@@:7:3

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-12.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-12.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/reusable-workflow-other-triggers.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/reusable-workflow-other-triggers.yml\")).run()?"
 ---
 warning[excessive-permissions]: overly broad permissions
   --> @@INPUT@@:1:1

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-2.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/issue-336-repro.yml\")).args([\"--pedantic\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/issue-336-repro.yml\")).args([\"--pedantic\"]).run()?"
 ---
 error[excessive-permissions]: overly broad permissions
  --> @@INPUT@@:4:3

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-3.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-3.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/workflow-default-perms.yml\")).args([\"--pedantic\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/workflow-default-perms.yml\")).args([\"--pedantic\"]).run()?"
 ---
 warning[excessive-permissions]: overly broad permissions
   --> @@INPUT@@:1:1

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-4.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-4.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/workflow-read-all.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/workflow-read-all.yml\")).run()?"
 ---
 warning[excessive-permissions]: overly broad permissions
  --> @@INPUT@@:3:1

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-5.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-5.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/workflow-write-all.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/workflow-write-all.yml\")).run()?"
 ---
 error[excessive-permissions]: overly broad permissions
  --> @@INPUT@@:3:1

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-6.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-6.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/workflow-empty-perms.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/workflow-empty-perms.yml\")).run()?"
 ---
 No findings to report. Good job!

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-7.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-7.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/jobs-broaden-permissions.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/jobs-broaden-permissions.yml\")).run()?"
 ---
 warning[excessive-permissions]: overly broad permissions
   --> @@INPUT@@:6:3

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-8.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-8.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/workflow-write-explicit.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/workflow-write-explicit.yml\")).run()?"
 ---
 error[excessive-permissions]: overly broad permissions
  --> @@INPUT@@:5:3

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions-9.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions-9.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/workflow-default-perms-all-jobs-explicit.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/workflow-default-perms-all-jobs-explicit.yml\")).run()?"
 ---
 No findings to report. Good job! (1 suppressed)

--- a/tests/integration/snapshots/integration__snapshot__excessive_permissions.snap
+++ b/tests/integration/snapshots/integration__snapshot__excessive_permissions.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"excessive-permissions/issue-336-repro.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"excessive-permissions/issue-336-repro.yml\")).run()?"
 ---
 No findings to report. Good job! (1 suppressed)

--- a/tests/integration/snapshots/integration__snapshot__forbidden_uses-2.snap
+++ b/tests/integration/snapshots/integration__snapshot__forbidden_uses-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().config(input_under_test(&format!(\"forbidden-uses/configs/{config}.yml\"))).input(input_under_test(\"forbidden-uses/forbidden-uses-menagerie.yml\")).run()?"
-snapshot_kind: text
 ---
 error[forbidden-uses]: forbidden action used
   --> @@INPUT@@:12:9

--- a/tests/integration/snapshots/integration__snapshot__forbidden_uses-3.snap
+++ b/tests/integration/snapshots/integration__snapshot__forbidden_uses-3.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().config(input_under_test(&format!(\"forbidden-uses/configs/{config}.yml\"))).input(input_under_test(\"forbidden-uses/forbidden-uses-menagerie.yml\")).run()?"
-snapshot_kind: text
 ---
 error[forbidden-uses]: forbidden action used
   --> @@INPUT@@:12:9

--- a/tests/integration/snapshots/integration__snapshot__forbidden_uses-4.snap
+++ b/tests/integration/snapshots/integration__snapshot__forbidden_uses-4.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().config(input_under_test(&format!(\"forbidden-uses/configs/{config}.yml\"))).input(input_under_test(\"forbidden-uses/forbidden-uses-menagerie.yml\")).run()?"
-snapshot_kind: text
 ---
 error[forbidden-uses]: forbidden action used
   --> @@INPUT@@:13:9

--- a/tests/integration/snapshots/integration__snapshot__forbidden_uses.snap
+++ b/tests/integration/snapshots/integration__snapshot__forbidden_uses.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().config(input_under_test(&format!(\"forbidden-uses/configs/{config}.yml\"))).input(input_under_test(\"forbidden-uses/forbidden-uses-menagerie.yml\")).run()?"
-snapshot_kind: text
 ---
 No findings to report. Good job!

--- a/tests/integration/snapshots/integration__snapshot__github_env-2.snap
+++ b/tests/integration/snapshots/integration__snapshot__github_env-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"github-env/github-path.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"github-env/github-path.yml\")).run()?"
 ---
 error[github-env]: dangerous use of environment file
   --> @@INPUT@@:14:9

--- a/tests/integration/snapshots/integration__snapshot__github_env-3.snap
+++ b/tests/integration/snapshots/integration__snapshot__github_env-3.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"github-env/issue-397-repro.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"github-env/issue-397-repro.yml\")).run()?"
 ---
 error[github-env]: dangerous use of environment file
   --> @@INPUT@@:14:9

--- a/tests/integration/snapshots/integration__snapshot__github_env.snap
+++ b/tests/integration/snapshots/integration__snapshot__github_env.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"github-env/action.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"github-env/action.yml\")).run()?"
 ---
 error[github-env]: dangerous use of environment file
   --> @@INPUT@@:10:7

--- a/tests/integration/snapshots/integration__snapshot__insecure_commands-2.snap
+++ b/tests/integration/snapshots/integration__snapshot__insecure_commands-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"insecure-commands.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"insecure-commands.yml\")).run()?"
 ---
 error[insecure-commands]: execution of insecure workflow commands is enabled
   --> @@INPUT@@:10:5

--- a/tests/integration/snapshots/integration__snapshot__insecure_commands-3.snap
+++ b/tests/integration/snapshots/integration__snapshot__insecure_commands-3.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"insecure-commands/action.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"insecure-commands/action.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 error[insecure-commands]: execution of insecure workflow commands is enabled
   --> @@INPUT@@:18:7

--- a/tests/integration/snapshots/integration__snapshot__insecure_commands.snap
+++ b/tests/integration/snapshots/integration__snapshot__insecure_commands.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"insecure-commands.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"insecure-commands.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 error[insecure-commands]: execution of insecure workflow commands is enabled
   --> @@INPUT@@:10:5

--- a/tests/integration/snapshots/integration__snapshot__invalid_inputs.snap
+++ b/tests/integration/snapshots/integration__snapshot__invalid_inputs.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().output(OutputMode::Stderr).offline(true).input(input_under_test(\"invalid/invalid-workflow.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().expects_failure(true).offline(true).input(input_under_test(\"invalid/invalid-workflow.yml\")).run()?"
 ---
 fatal: no audit was performed
 failed to register input: @@INPUT@@

--- a/tests/integration/snapshots/integration__snapshot__overprovisioned_secrets.snap
+++ b/tests/integration/snapshots/integration__snapshot__overprovisioned_secrets.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"overprovisioned-secrets.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"overprovisioned-secrets.yml\")).run()?"
 ---
 warning[overprovisioned-secrets]: excessively provisioned secrets
   --> @@INPUT@@:12:18

--- a/tests/integration/snapshots/integration__snapshot__ref_confusion-2.snap
+++ b/tests/integration/snapshots/integration__snapshot__ref_confusion-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"ref-confusion/issue-518-repro.yml\")).offline(false).run()?"
-snapshot_kind: text
 ---
 error[unpinned-uses]: unpinned action reference
   --> @@INPUT@@:12:9

--- a/tests/integration/snapshots/integration__snapshot__ref_confusion.snap
+++ b/tests/integration/snapshots/integration__snapshot__ref_confusion.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"ref-confusion.yml\")).offline(false).run()?"
-snapshot_kind: text
 ---
 warning[ref-confusion]: git ref for action with ambiguous ref type
   --> @@INPUT@@:11:9

--- a/tests/integration/snapshots/integration__snapshot__secrets_inherit.snap
+++ b/tests/integration/snapshots/integration__snapshot__secrets_inherit.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"secrets-inherit.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"secrets-inherit.yml\")).run()?"
 ---
 warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> @@INPUT@@:7:5

--- a/tests/integration/snapshots/integration__snapshot__self_hosted-2.snap
+++ b/tests/integration/snapshots/integration__snapshot__self_hosted-2.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"self-hosted.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"self-hosted.yml\")).run()?"
 ---
 No findings to report. Good job! (1 suppressed)

--- a/tests/integration/snapshots/integration__snapshot__self_hosted-3.snap
+++ b/tests/integration/snapshots/integration__snapshot__self_hosted-3.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"self-hosted/self-hosted-runner-label.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"self-hosted/self-hosted-runner-label.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 note[self-hosted-runner]: runs on a self-hosted runner
  --> @@INPUT@@:8:5

--- a/tests/integration/snapshots/integration__snapshot__self_hosted-4.snap
+++ b/tests/integration/snapshots/integration__snapshot__self_hosted-4.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"self-hosted/self-hosted-runner-group.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"self-hosted/self-hosted-runner-group.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 note[self-hosted-runner]: runs on a self-hosted runner
  --> @@INPUT@@:8:5

--- a/tests/integration/snapshots/integration__snapshot__self_hosted-5.snap
+++ b/tests/integration/snapshots/integration__snapshot__self_hosted-5.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"self-hosted/self-hosted-matrix-dimension.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"self-hosted/self-hosted-matrix-dimension.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 note[self-hosted-runner]: runs on a self-hosted runner
   --> @@INPUT@@:10:5

--- a/tests/integration/snapshots/integration__snapshot__self_hosted-6.snap
+++ b/tests/integration/snapshots/integration__snapshot__self_hosted-6.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"self-hosted/self-hosted-matrix-inclusion.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"self-hosted/self-hosted-matrix-inclusion.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 note[self-hosted-runner]: runs on a self-hosted runner
   --> @@INPUT@@:10:5

--- a/tests/integration/snapshots/integration__snapshot__self_hosted-7.snap
+++ b/tests/integration/snapshots/integration__snapshot__self_hosted-7.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"self-hosted/self-hosted-matrix-exclusion.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"self-hosted/self-hosted-matrix-exclusion.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 No findings to report. Good job!

--- a/tests/integration/snapshots/integration__snapshot__self_hosted-8.snap
+++ b/tests/integration/snapshots/integration__snapshot__self_hosted-8.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"self-hosted/issue-283-repro.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"self-hosted/issue-283-repro.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 No findings to report. Good job!

--- a/tests/integration/snapshots/integration__snapshot__self_hosted.snap
+++ b/tests/integration/snapshots/integration__snapshot__self_hosted.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"self-hosted.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"self-hosted.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 note[self-hosted-runner]: runs on a self-hosted runner
   --> @@INPUT@@:10:5

--- a/tests/integration/snapshots/integration__snapshot__template_injection-2.snap
+++ b/tests/integration/snapshots/integration__snapshot__template_injection-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"template-injection/template-injection-dynamic-matrix.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"template-injection/template-injection-dynamic-matrix.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 warning[template-injection]: code injection via template expansion
   --> @@INPUT@@:19:9

--- a/tests/integration/snapshots/integration__snapshot__template_injection-3.snap
+++ b/tests/integration/snapshots/integration__snapshot__template_injection-3.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"template-injection/issue-22-repro.yml\")).run()?"
-snapshot_kind: text
 ---
 No findings to report. Good job! (2 suppressed)

--- a/tests/integration/snapshots/integration__snapshot__template_injection-4.snap
+++ b/tests/integration/snapshots/integration__snapshot__template_injection-4.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"template-injection/pr-317-repro.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"template-injection/pr-317-repro.yml\")).run()?"
 ---
 warning[template-injection]: code injection via template expansion
   --> @@INPUT@@:27:9

--- a/tests/integration/snapshots/integration__snapshot__template_injection-5.snap
+++ b/tests/integration/snapshots/integration__snapshot__template_injection-5.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"template-injection/static-env.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"template-injection/static-env.yml\")).run()?"
 ---
 help[template-injection]: code injection via template expansion
   --> @@INPUT@@:41:9

--- a/tests/integration/snapshots/integration__snapshot__template_injection-7.snap
+++ b/tests/integration/snapshots/integration__snapshot__template_injection-7.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"template-injection/issue-418-repro.yml\")).run()?"
-snapshot_kind: text
 ---
 No findings to report. Good job!

--- a/tests/integration/snapshots/integration__snapshot__template_injection-8.snap
+++ b/tests/integration/snapshots/integration__snapshot__template_injection-8.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"template-injection/pr-425-backstop/action.yml\")).run()?"
-snapshot_kind: text
 ---
 error[template-injection]: code injection via template expansion
   --> @@INPUT@@:12:7

--- a/tests/integration/snapshots/integration__snapshot__template_injection.snap
+++ b/tests/integration/snapshots/integration__snapshot__template_injection.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"template-injection/template-injection-static-matrix.yml\")).args([\"--persona=auditor\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"template-injection/template-injection-static-matrix.yml\")).args([\"--persona=auditor\"]).run()?"
 ---
 No findings to report. Good job!

--- a/tests/integration/snapshots/integration__snapshot__unpinned-uses-composite-config-2.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned-uses-composite-config-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().config(input_under_test(\"unpinned-uses/configs/composite-2.yml\")).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
 error[unpinned-uses]: unpinned action reference
   --> @@INPUT@@:13:9

--- a/tests/integration/snapshots/integration__snapshot__unpinned-uses-composite-config.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned-uses-composite-config.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().config(input_under_test(\"unpinned-uses/configs/composite.yml\")).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
 error[unpinned-uses]: unpinned action reference
   --> @@INPUT@@:11:9

--- a/tests/integration/snapshots/integration__snapshot__unpinned-uses-default-config.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned-uses-default-config.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
 error[unpinned-uses]: unpinned action reference
   --> @@INPUT@@:13:9

--- a/tests/integration/snapshots/integration__snapshot__unpinned-uses-empty-config.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned-uses-empty-config.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().config(input_under_test(\"unpinned-uses/configs/empty.yml\")).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
 error[unpinned-uses]: unpinned action reference
   --> @@INPUT@@:11:9

--- a/tests/integration/snapshots/integration__snapshot__unpinned-uses-hash-pin-everything-config.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned-uses-hash-pin-everything-config.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().config(input_under_test(\"unpinned-uses/configs/hash-pin-everything.yml\")).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
 error[unpinned-uses]: unpinned action reference
   --> @@INPUT@@:11:9

--- a/tests/integration/snapshots/integration__snapshot__unpinned-uses-ref-pin-everything-config.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned-uses-ref-pin-everything-config.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().config(input_under_test(\"unpinned-uses/configs/ref-pin-everything.yml\")).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
 ---
 error[unpinned-uses]: unpinned action reference
   --> @@INPUT@@:13:9

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-10.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-10.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().output(OutputMode::Stderr).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-11.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-11.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().output(OutputMode::Stderr).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-2.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-2.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"unpinned-uses.yml\")).run()?"
-snapshot_kind: text
 ---
 error[unpinned-uses]: unpinned action reference
   --> @@INPUT@@:11:9

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-3.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-3.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"unpinned-uses/action.yml\")).args([\"--pedantic\"]).run()?"
-snapshot_kind: text
 ---
 error[unpinned-uses]: unpinned action reference
  --> @@INPUT@@:8:7

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-4.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-4.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"unpinned-uses/issue-433-repro.yml\")).args([\"--pedantic\"]).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"unpinned-uses/issue-433-repro.yml\")).args([\"--pedantic\"]).run()?"
 ---
 No findings to report. Good job!

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-5.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-5.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"unpinned-uses/issue-659-repro.yml\")).args([\"--pedantic\"]).run()?"
-snapshot_kind: text
 ---
 warning[excessive-permissions]: overly broad permissions
   --> @@INPUT@@:1:1

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-6.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-6.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().output(OutputMode::Stderr).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-7.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-7.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().output(OutputMode::Stderr).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-8.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-8.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().output(OutputMode::Stderr).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses-9.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses-9.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().output(OutputMode::Stderr).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().expects_failure(true).config(input_under_test(&format!(\"unpinned-uses/configs/{tc}.yml\",))).input(input_under_test(\"unpinned-uses/menagerie-of-uses.yml\")).run()?"
 ---
  INFO zizmor: skipping impostor-commit: can't run without a GitHub API token
  INFO zizmor: skipping ref-confusion: can't run without a GitHub API token

--- a/tests/integration/snapshots/integration__snapshot__unpinned_uses.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_uses.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"unpinned-uses.yml\")).args([\"--pedantic\"]).run()?"
-snapshot_kind: text
 ---
 error[unpinned-uses]: unpinned action reference
   --> @@INPUT@@:11:9

--- a/tests/integration/snapshots/integration__snapshot__unredacted_secrets.snap
+++ b/tests/integration/snapshots/integration__snapshot__unredacted_secrets.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(workflow_under_test(\"unredacted-secrets.yml\")).run()?"
-snapshot_kind: text
+expression: "zizmor().input(input_under_test(\"unredacted-secrets.yml\")).run()?"
 ---
 warning[unredacted-secrets]: leaked secret values
   --> @@INPUT@@:14:18


### PR DESCRIPTION
The data was outdated, but is apparently not causing a test failure. See also https://github.com/mitsuhiko/insta/issues/766

Also removes `snapshot_kind: text` which is apparently not emitted anymore because it is the default anyway (https://github.com/mitsuhiko/insta/pull/690).

Follow-up for #696, #698, and some earlier pull requests which had also changed the expressions
