### PR TITLE
chore: remove duplicate context

### DIFF
--- a/src/github_api.rs
+++ b/src/github_api.rs
@@ -185,7 +185,7 @@ impl Client {
 
         let resp = self.http.get(&url).send().await?;
         Client::resp_present(resp).with_context(|| {
-            format!("{owner}/{repo}: error from the GitHub APi while checking {branch}")
+            format!("{owner}/{repo}: error from the GitHub API while checking {branch}")
         })
     }
 
@@ -199,7 +199,7 @@ impl Client {
 
         let resp = self.http.get(&url).send().await?;
         Client::resp_present(resp).with_context(|| {
-            format!("{owner}/{repo}: error from the GitHub APi while checking {tag}")
+            format!("{owner}/{repo}: error from the GitHub API while checking {tag}")
         })
     }
 


### PR DESCRIPTION
Since recent changes `longest_tag_for_commit` already adds the error context (`with_context(...)`) itself, see https://github.com/woodruffw/zizmor/pull/713/commits/06f8f51b5a215f9446c2e14b3cf98448f578976d.