### PR TITLE
bugfix: fix edge case in remote audit input collection

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -33,6 +33,9 @@ of `zizmor`.
 * The SARIF output format now includes a rule name for each rule descriptor,
   which should improve rendering behavior in SARIF viewers like the
   VS Code SARIF Viewer extension (#710)
+* Fixed a bug where `zizmor` would fail to collection actions defined
+  within subdirectories of `.github/workflows` when collecting from
+  a remote source (#731)
 
 ## v1.6.0
 

--- a/tests/integration/e2e.rs
+++ b/tests/integration/e2e.rs
@@ -38,6 +38,23 @@ fn issue_569() -> Result<()> {
     Ok(())
 }
 
+#[cfg_attr(not(feature = "gh-token-tests"), ignore)]
+#[test]
+fn issue_726() -> Result<()> {
+    // Regression test for #726.
+    // See: https://github.com/woodruffw/zizmor/issues/726
+    // See: https://github.com/woodruffw-experiments/zizmor-bug-726
+    insta::assert_snapshot!(
+        zizmor()
+            .offline(false)
+            .output(OutputMode::Both)
+            .args(["--no-online-audits"])
+            .input("woodruffw-experiments/zizmor-bug-726@a038d1a35")
+            .run()?
+    );
+    Ok(())
+}
+
 #[test]
 fn menagerie() -> Result<()> {
     // Respects .gitignore by default.

--- a/tests/integration/snapshots/integration__e2e__issue_726.snap
+++ b/tests/integration/snapshots/integration__e2e__issue_726.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration/e2e.rs
+expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--no-online-audits\"]).input(\"woodruffw-experiments/zizmor-bug-726@a038d1a35\").run()?"
+---
+ INFO collect_inputs: zizmor: collected 6 inputs from woodruffw-experiments/zizmor-bug-726
+ INFO zizmor: skipping impostor-commit: offline audits only requested
+ INFO zizmor: skipping ref-confusion: offline audits only requested
+ INFO zizmor: skipping known-vulnerable-actions: offline audits only requested
+ INFO zizmor: skipping forbidden-uses: audit not configured
+ INFO zizmor: skipping stale-action-refs: offline audits only requested
+ INFO audit: zizmor: 🌈 completed .github/actions/custom-action/action.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/actions/custom-action/action.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/custom-action/action.yml
+ INFO audit: zizmor: 🌈 completed .github/workflows/hello.yml
+ INFO audit: zizmor: 🌈 completed arbitrary/subdir/.github/workflows/hello.yml
+ INFO audit: zizmor: 🌈 completed arbitrary/subdir/custom-action/action.yml
+No findings to report. Good job!


### PR DESCRIPTION
This ensures that we correctly collect an action
defined under `.github/workflows/`, e.g.
`<repo>/.github/workflows/my-action/action.yml`.

This isn't a very common thing to do, but it's
perfectly valid from GitHub's perspective.

~~Needs tests. I need to think about a good way to test this.~~

Fixes #726.