### PR TITLE
bugfix: warn on parse errors instead of panic

### DIFF
--- a/tests/integration/e2e.rs
+++ b/tests/integration/e2e.rs
@@ -207,3 +207,12 @@ fn invalid_inputs() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn empty_workflow() -> Result<()> {
+    for tc in ["empty"] {
+        insta::assert_snapshot!(zizmor().input(input_under_test(&format!("{tc}"))).run()?);
+    }
+
+    Ok(())
+}

--- a/tests/integration/snapshots/integration__e2e__empty_workflow.snap
+++ b/tests/integration/snapshots/integration__e2e__empty_workflow.snap
@@ -1,0 +1,5 @@
+---
+source: tests/integration/e2e.rs
+expression: "zizmor().input(input_under_test(&format!(\"{tc}\"))).run()?"
+---
+No findings to report. Good job! (2 suppressed)

--- a/tests/integration/test-data/empty/.github/workflows/filled.yml
+++ b/tests/integration/test-data/empty/.github/workflows/filled.yml
@@ -1,0 +1,8 @@
+on:
+  workflow_call:
+jobs:
+  filled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: filled
+        run: echo "filled"


### PR DESCRIPTION
Matches on the branch to add files to the input lists, and sends out a warning where the error branch is hit rather than panicking.

Works towards #725 