### PR TITLE
feat: emit pedantic finding for tagged OCI images

### DIFF
--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1449,24 +1449,24 @@ By default, this audit applies the following policy:
 
 * Regular findings are created for all image references missing a tag
 
-```yaml
-container:
-  image: foo/bar
-```
+    ```yaml
+    container:
+      image: foo/bar
+    ```
 
-or using the `latest` tag:
+    or using the `latest` tag:
 
-```yaml
-container:
-  image: foo/bar:latest
-```
+    ```yaml
+    container:
+      image: foo/bar:latest
+    ```
 
 * Pedantic findings are created for all image references using a tag (`!= latest`) rather than SHA256 hash.
 
-```yaml
-container:
-  image: foo/bar:not-a-sha256
-```
+    ```yaml
+    container:
+      image: foo/bar:not-a-sha256
+    ```
 
 Other resources:
 

--- a/docs/audits.md
+++ b/docs/audits.md
@@ -1445,21 +1445,35 @@ This can be a security risk:
 1. Registries may not consistently enforce immutable image tags
 2. Completely unpinned images can be changed at any time by the OCI registry.
 
-Other resources:
+By default, this audit applies the following policy:
 
-- [Aqua: The Challenges of Uniquely Identifying Your Images]
-- [GitHub: Safeguard your containers with new container signing capability in GitHub Actions]
+* Regular findings are created for all image references missing a tag
 
 ```yaml
 container:
   image: foo/bar
 ```
-and where that version is `latest`:
+
+or using the `latest` tag:
 
 ```yaml
 container:
   image: foo/bar:latest
 ```
+
+* Pedantic findings are created for all image references using a tag (`!= latest`) rather than SHA256 hash.
+
+```yaml
+container:
+  image: foo/bar:not-a-sha256
+```
+
+Other resources:
+
+- [Aqua: The Challenges of Uniquely Identifying Your Images]
+- [GitHub: Safeguard your containers with new container signing capability in GitHub Actions]
+
+
 
 ### Remediation
 

--- a/tests/integration/snapshot.rs
+++ b/tests/integration/snapshot.rs
@@ -691,6 +691,7 @@ fn unpinned_images() -> Result<()> {
     insta::assert_snapshot!(
         zizmor()
             .input(input_under_test("unpinned-images.yml"))
+            .args(["--persona=pedantic"])
             .run()?
     );
 

--- a/tests/integration/snapshots/integration__e2e__issue_569.snap
+++ b/tests/integration/snapshots/integration__e2e__issue_569.snap
@@ -183,4 +183,4 @@ error[unpinned-uses]: unpinned action reference
    |
    = note: audit confidence → High
 
-47 findings (28 suppressed): 0 unknown, 0 informational, 1 low, 0 medium, 18 high
+48 findings (29 suppressed): 0 unknown, 0 informational, 1 low, 0 medium, 18 high

--- a/tests/integration/snapshots/integration__snapshot__unpinned_images.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_images.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration/snapshot.rs
-expression: "zizmor().input(input_under_test(\"unpinned-images.yml\")).run()?"
+expression: "zizmor().input(input_under_test(\"unpinned-images.yml\")).args([\"--persona=pedantic\"]).run()?"
 ---
 error[unpinned-images]: unpinned image references
   --> @@INPUT@@:16:7
@@ -34,4 +34,20 @@ error[unpinned-images]: unpinned image references
    |
    = note: audit confidence → High
 
-6 findings (2 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 4 high
+error[unpinned-images]: unpinned image references
+  --> @@INPUT@@:46:7
+   |
+46 |       image: fake.example.com/example:0.0.348
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
+   |
+   = note: audit confidence → High
+
+error[unpinned-images]: unpinned image references
+  --> @@INPUT@@:54:9
+   |
+54 |         image: fake.example.com/redis:7.4.3
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ container image is not pinned to a SHA256 hash
+   |
+   = note: audit confidence → High
+
+6 findings: 0 unknown, 0 informational, 0 low, 0 medium, 6 high

--- a/tests/integration/snapshots/integration__snapshot__unpinned_images.snap
+++ b/tests/integration/snapshots/integration__snapshot__unpinned_images.snap
@@ -34,4 +34,4 @@ error[unpinned-images]: unpinned image references
    |
    = note: audit confidence → High
 
-4 findings: 0 unknown, 0 informational, 0 low, 0 medium, 4 high
+6 findings (2 suppressed): 0 unknown, 0 informational, 0 low, 0 medium, 4 high


### PR DESCRIPTION
Pedantic findings are emitted by the unpinned-images audit when it encounters OCI image references that use a tag other than `latest`.

The pedantic finding is resolved, will not be produced when the image reference uses a SHA256 hash rather than a tag.

This closes #736