### PR TITLE
feat: handle reducible index subexpressions

### DIFF
--- a/src/audit/obfuscation.rs
+++ b/src/audit/obfuscation.rs
@@ -56,12 +56,12 @@ impl Obfuscation {
 
         // Check for some common expression obfuscation patterns.
 
-        // Expressions that can be constant folded should be simplified to
+        // Expressions that can be constant reduced should be simplified to
         // their evaluated form.
-        if expr.constant_foldable() {
-            annotations.push("expression can be simplified via constant folding");
-        } else if expr.has_constant_foldable_subexpr() {
-            annotations.push("expression contains constant foldable subexpression");
+        if expr.constant_reducible() {
+            annotations.push("expression can be replaced by its static evaluation");
+        } else if expr.has_constant_reducible_subexpr() {
+            annotations.push("expression contains constant-reducible subexpression");
         }
 
         // TODO: calculate call breadth/depth and flag above thresholds.

--- a/tests/integration/snapshots/integration__e2e__issue_569.snap
+++ b/tests/integration/snapshots/integration__e2e__issue_569.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/integration/e2e.rs
 expression: "zizmor().offline(false).output(OutputMode::Both).args([\"--no-online-audits\",\n\"--collect=workflows-only\"]).input(\"python/cpython@f963239ff1f986742d4c6bab2ab7b73f5a4047f6\").run()?"
+snapshot_kind: text
 ---
  INFO zizmor: skipping impostor-commit: offline audits only requested
  INFO zizmor: skipping ref-confusion: offline audits only requested
@@ -87,7 +88,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
    --> .github/workflows/build.yml:184:18
     |
 184 |       Windows MSI${{ '' }}
-    |                  --------- help: expression can be simplified via constant folding
+    |                  --------- help: expression can be replaced by its static evaluation
     |
     = note: audit confidence → High
 

--- a/tests/integration/snapshots/integration__snapshot__obfuscation.snap
+++ b/tests/integration/snapshots/integration__snapshot__obfuscation.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/integration/snapshot.rs
 expression: "zizmor().input(input_under_test(\"obfuscation.yml\")).run()?"
+snapshot_kind: text
 ---
 help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:12:9
@@ -178,4 +179,12 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
    |
    = note: audit confidence → High
 
-29 findings (7 suppressed): 0 unknown, 0 informational, 22 low, 0 medium, 0 high
+help[obfuscation]: obfuscated usage of GitHub Actions features
+  --> @@INPUT@@:52:16
+   |
+52 |           echo ${{ foobar[format('{0}', 'event')]}}
+   |                ------------------------------------ help: expression contains constant foldable subexpression
+   |
+   = note: audit confidence → High
+
+31 findings (1 ignored, 7 suppressed): 0 unknown, 0 informational, 23 low, 0 medium, 0 high

--- a/tests/integration/snapshots/integration__snapshot__obfuscation.snap
+++ b/tests/integration/snapshots/integration__snapshot__obfuscation.snap
@@ -71,7 +71,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:29:16
    |
 29 |           echo ${{ '' }}
-   |                --------- help: expression can be simplified via constant folding
+   |                --------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -79,7 +79,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:30:16
    |
 30 |           echo ${{ 'a' }}
-   |                ---------- help: expression can be simplified via constant folding
+   |                ---------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -87,7 +87,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:31:16
    |
 31 |           echo ${{ true }}
-   |                ----------- help: expression can be simplified via constant folding
+   |                ----------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -95,7 +95,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:32:16
    |
 32 |           echo ${{ true && false }}
-   |                -------------------- help: expression can be simplified via constant folding
+   |                -------------------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -103,7 +103,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:33:16
    |
 33 |           echo ${{ true || false }}
-   |                -------------------- help: expression can be simplified via constant folding
+   |                -------------------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -111,7 +111,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:34:16
    |
 34 |           echo ${{ 1 > 2 || true }}
-   |                -------------------- help: expression can be simplified via constant folding
+   |                -------------------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -119,7 +119,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:35:16
    |
 35 |           echo ${{ 1 != 2}}
-   |                ------------ help: expression can be simplified via constant folding
+   |                ------------ help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -127,7 +127,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:39:16
    |
 39 |           echo ${{ format('{0}', 'abc') }}
-   |                --------------------------- help: expression can be simplified via constant folding
+   |                --------------------------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -135,7 +135,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:40:16
    |
 40 |           echo ${{ format('{0} {1}', 'abc', 'def') }}
-   |                -------------------------------------- help: expression can be simplified via constant folding
+   |                -------------------------------------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -143,7 +143,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:41:16
    |
 41 |           echo ${{ format('{0} {1}', 'abc', format('{0}', 'def')) }}
-   |                ----------------------------------------------------- help: expression can be simplified via constant folding
+   |                ----------------------------------------------------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -151,7 +151,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:42:16
    |
 42 |           echo ${{ startsWith('abc', 'a') }}
-   |                ----------------------------- help: expression can be simplified via constant folding
+   |                ----------------------------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -159,7 +159,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:43:16
    |
 43 |           echo ${{ ENDSWITH('abc', 'c') }}
-   |                --------------------------- help: expression can be simplified via constant folding
+   |                --------------------------- help: expression can be replaced by its static evaluation
    |
    = note: audit confidence → High
 
@@ -167,7 +167,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:48:16
    |
 48 |           echo ${{ format('{0}, {1}', github.event.number, format('{0}', 'abc')) }}
-   |                -------------------------------------------------------------------- help: expression contains constant foldable subexpression
+   |                -------------------------------------------------------------------- help: expression contains constant-reducible subexpression
    |
    = note: audit confidence → High
 
@@ -175,7 +175,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:50:16
    |
 50 |           echo ${{ format('{0}, {1}', github.event.number, format('{0} {1}', github.event.number, true || false)) }}
-   |                ----------------------------------------------------------------------------------------------------- help: expression contains constant foldable subexpression
+   |                ----------------------------------------------------------------------------------------------------- help: expression contains constant-reducible subexpression
    |
    = note: audit confidence → High
 
@@ -183,7 +183,7 @@ help[obfuscation]: obfuscated usage of GitHub Actions features
   --> @@INPUT@@:52:16
    |
 52 |           echo ${{ foobar[format('{0}', 'event')]}}
-   |                ------------------------------------ help: expression contains constant foldable subexpression
+   |                ------------------------------------ help: expression contains constant-reducible subexpression
    |
    = note: audit confidence → High
 

--- a/tests/integration/test-data/obfuscation.yml
+++ b/tests/integration/test-data/obfuscation.yml
@@ -43,8 +43,10 @@ jobs:
           echo ${{ ENDSWITH('abc', 'c') }}
 
       # foldable subexpressions
-      - run: |
+      - run: | # zizmor: ignore[template-injection] not this test
           # inner format(...) is foldable
           echo ${{ format('{0}, {1}', github.event.number, format('{0}', 'abc')) }}
           # inner || is foldable
           echo ${{ format('{0}, {1}', github.event.number, format('{0} {1}', github.event.number, true || false)) }}
+          # inner [...] is foldable
+          echo ${{ foobar[format('{0}', 'event')]}}

--- a/tests/integration/test-data/obfuscation.yml
+++ b/tests/integration/test-data/obfuscation.yml
@@ -24,7 +24,7 @@ jobs:
   obfuscated-exprs:
     runs-on: ubuntu-latest
     steps:
-      # trivially foldable expressions
+      # trivially reducible expressions
       - run: |
           echo ${{ '' }}
           echo ${{ 'a' }}
@@ -34,7 +34,7 @@ jobs:
           echo ${{ 1 > 2 || true }}
           echo ${{ 1 != 2}}
 
-      # trivially foldable functions
+      # trivially reducible functions
       - run: |
           echo ${{ format('{0}', 'abc') }}
           echo ${{ format('{0} {1}', 'abc', 'def') }}
@@ -42,11 +42,11 @@ jobs:
           echo ${{ startsWith('abc', 'a') }}
           echo ${{ ENDSWITH('abc', 'c') }}
 
-      # foldable subexpressions
+      # reducible subexpressions
       - run: | # zizmor: ignore[template-injection] not this test
-          # inner format(...) is foldable
+          # inner format(...) is reducible
           echo ${{ format('{0}, {1}', github.event.number, format('{0}', 'abc')) }}
-          # inner || is foldable
+          # inner || is reducible
           echo ${{ format('{0}, {1}', github.event.number, format('{0} {1}', github.event.number, true || false)) }}
-          # inner [...] is foldable
+          # inner [...] is reducible
           echo ${{ foobar[format('{0}', 'event')]}}


### PR DESCRIPTION
Index expressions can contain calls, etc.,
which themselves are constant reducible.

Also renamed everything from "constant foldable" to "constant reducible" since "foldable" means something specific that we're doing a superset of.